### PR TITLE
Use images from .wellcome-project

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+If provided images described in .wellcome-project will be used instead of referring to SSM.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+If provided images described in .wellcome-project will be used instead of referring to SSM.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -99,28 +99,15 @@ def cli(ctx, project_file, verbose, project_id, region_id, account_id, role_arn,
     project = projects.get(project_id)
     project['id'] = project_id
 
-    if verbose and project:
-        click.echo(f"Loaded {project_file} {project}")
-
     if role_arn:
         project['role_arn'] = role_arn
-        if verbose:
-            click.echo(f"Using role_arn {project['role_arn']}")
 
     if region_id:
         project['aws_region_name'] = region_id
-        if verbose:
-            click.echo(f"Using aws_region_name {project['aws_region_name']}")
 
     user_details = Iam(role_arn)
     caller_identity = user_details.caller_identity()
     underlying_caller_identity = user_details.caller_identity(underlying=True)
-
-    if verbose:
-        click.echo(f"Running as role {caller_identity['arn']}")
-        if caller_identity['arn'] != underlying_caller_identity['arn']:
-            click.echo(f"Underlying role {underlying_caller_identity['arn']}")
-        click.echo("")
 
     if account_id:
         project['account_id'] = account_id
@@ -128,7 +115,17 @@ def cli(ctx, project_file, verbose, project_id, region_id, account_id, role_arn,
         project['account_id'] = caller_identity['account_id']
 
     if verbose:
-        click.echo(f"Using account_id {project['account_id']}")
+        click.echo(click.style(f"Loaded {project_file}:", fg="cyan"))
+        pprint(project)
+        click.echo("")
+        click.echo(click.style(f"Using role_arn:         {project['role_arn']}", fg="cyan"))
+        click.echo(click.style(f"Using aws_region_name:  {project['aws_region_name']}", fg="cyan"))
+        click.echo(click.style(f"Running as role:        {caller_identity['arn']}", fg="cyan"))
+        if caller_identity['arn'] != underlying_caller_identity['arn']:
+            click.echo(click.style(f"Underlying role:        {underlying_caller_identity['arn']}", fg="cyan"))
+
+        click.echo(click.style(f"Using account_id:       {project['account_id']}", fg="cyan"))
+        click.echo("")
 
     ctx.obj = {
         'project_filepath': project_file,
@@ -168,18 +165,18 @@ def publish(ctx, service_id, namespace, label):
 
     ecr.login(profile_name)
 
-    remote_image_name, image_tag = ecr.publish_image(
+    remote_image_name, remote_image_tag, local_image_tag = ecr.publish_image(
         namespace,
         service_id,
         dry_run
     )
 
-    click.echo(click.style(f"Published Image {image_tag} to {remote_image_name}", fg="yellow"))
+    click.echo(click.style(f"Published Image {local_image_tag} to {remote_image_name}", fg="yellow"))
 
     ecr.retag_image(
         namespace,
         service_id,
-        image_tag,
+        remote_image_tag,
         label
     )
 
@@ -317,7 +314,7 @@ def deploy(ctx, release_id, environment_id, namespace, description):
         click.echo(click.style(f"*** {service_id}: Updated SSM path {ssm_path} to {image_name}", fg="yellow"))
 
         old_tag = image_name.split(":")[-1]
-        new_tag = environment_id
+        new_tag = f"env.{environment_id}"
 
         ecr.retag_image(
             namespace=namespace,
@@ -346,14 +343,30 @@ def deploy(ctx, release_id, environment_id, namespace, description):
 @click.pass_context
 def prepare(ctx, from_label, service_id, release_description):
     project = ctx.obj['project']
+    account_id = project['account_id']
+    region_id = project['aws_region_name']
     role_arn = ctx.obj['role_arn']
     dry_run = ctx.obj['dry_run']
 
+    ecr = Ecr(account_id, region_id, role_arn)
     releases_store = DynamoDbReleaseStore(project['id'], role_arn)
     parameter_store = SsmParameterStore(project['id'], role_arn)
     user_details = Iam(role_arn)
 
-    from_images = parameter_store.get_services_to_images(from_label)
+    image_repositories = project.get('image_repositories')
+
+    from_images = {}
+    if image_repositories:
+        for image in image_repositories:
+            service_id = image['id']
+            account_id = image.get('account_id', account_id)
+            namespace = image.get('namespace', DEFAULT_ECR_NAMESPACE)
+
+            image_details = ecr.describe_image(namespace, service_id, from_label, account_id)
+            from_images[image_details['service_id']] = image_details['ref']
+    else:
+        from_images = parameter_store.get_services_to_images(from_label)
+
     service_source = "latest"
     if service_id == "all":
         release_image = {}
@@ -362,7 +375,12 @@ def prepare(ctx, from_label, service_id, release_description):
         if _is_url(service_source):
             release_image = {service_id: service_source}
         else:
-            release_image = parameter_store.get_service_to_image(service_source, service_id)
+            if image_repositories:
+                image_details = ecr.describe_image(namespace, service_id, service_source, account_id)
+                release_image = {image_details['service_id']: image_details['ref']}
+            else:
+                release_image = parameter_store.get_service_to_image(service_source, service_id)
+
     release_images = {**from_images, **release_image}
 
     if not release_images:

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -324,14 +324,15 @@ def deploy(ctx, release_id, environment_id, namespace, description):
             dry_run=dry_run
         )
 
-        click.echo(click.style(f"*** {service_id}: Retagged image {service_id}:{old_tag} to {service_id}:{new_tag}", fg="yellow"))
+        click.echo(click.style(
+            f"*** {service_id}: Retagged image {service_id}:{old_tag} to {service_id}:{new_tag}", fg="yellow")
+        )
         click.echo("")
 
     if dry_run:
         click.echo("dry-run, not created.")
 
     click.echo(click.style(f"Deployed {service_id} to {new_tag}", fg="green"))
-
 
 
 @cli.command()
@@ -397,9 +398,13 @@ def prepare(ctx, from_label, service_id, release_description):
 
     click.echo("")
     if service_id == "all":
-        click.echo(click.style(f"Prepared release from images in {from_label}", fg="blue"))
+        click.echo(click.style(
+            f"Prepared release from images in {from_label}", fg="blue")
+        )
     else:
-        click.echo(click.style(f"Prepared release from images in {from_label} with {service_id} from {service_source}", fg="blue"))
+        click.echo(click.style(
+            f"Prepared release from images in {from_label} with {service_id} from {service_source}", fg="blue")
+        )
 
     click.echo(click.style(f"Requested by: {release['requested_by']}", fg="yellow"))
     click.echo(click.style(f"Date created: {release['date_created']}", fg="yellow"))

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -22,20 +22,21 @@ class Ecr:
         repo_root = cmd("git", "rev-parse", "--show-toplevel")
         release_file = os.path.join(repo_root, ".releases", service_id)
 
-        print(f"*** Retrieving image tag for {service_id} from {release_file}")
-
         return open(release_file).read().strip()
 
     @staticmethod
     def _get_repository_name(namespace, service_id):
         return f"{namespace}/{service_id}"
 
-    def publish_image(self, namespace, service_id, dry_run=False):
-        image_tag = Ecr._get_release_image_tag(service_id)
-        repository_name = Ecr._get_repository_name(namespace, service_id)
+    def _get_full_repository_uri(self, namespace, service_id, tag):
+        return f"{self.ecr_base_uri}/{Ecr._get_repository_name(namespace, service_id)}:{tag}"
 
-        local_image_name = f"{service_id}:{image_tag}"
-        remote_image_name = f"{self.ecr_base_uri}/{repository_name}:{image_tag}"
+    def publish_image(self, namespace, service_id, dry_run=False):
+        local_image_tag = Ecr._get_release_image_tag(service_id)
+        local_image_name = f"{service_id}:{local_image_tag}"
+
+        remote_image_tag = f"ref.{local_image_tag}"
+        remote_image_name = self._get_full_repository_uri(namespace, service_id, remote_image_tag)
 
         if not dry_run:
             try:
@@ -45,7 +46,52 @@ class Ecr:
             finally:
                 cmd('docker', 'rmi', remote_image_name)
 
-        return remote_image_name, image_tag
+        return remote_image_name, remote_image_tag, local_image_tag
+
+    def describe_image(self, namespace, service_id, tag, account_id=None):
+        repository_name = Ecr._get_repository_name(namespace, service_id)
+        if not account_id:
+            account_id = self.account_id
+
+        result = self.ecr.describe_images(
+            registryId=account_id,
+            repositoryName=repository_name,
+            imageIds=[
+                {"imageTag": tag}
+            ]
+        )
+
+        if len(result['imageDetails']) == 0:
+            raise RuntimeError(f"No matching images found for {repository_name}:{tag}!")
+
+        if len(result['imageDetails']) > 1:
+            raise RuntimeError(f"Multiple matching images found for {repository_name}:{tag}!")
+
+        image_details = result['imageDetails'][0]
+
+        is_latest = 'latest' in image_details['imageTags']
+
+        ref_tags = [image for image in image_details['imageTags'] if image.startswith("ref.")]
+        env_tags = [image for image in image_details['imageTags'] if image.startswith("env.")]
+
+        envs = {env_tag.split('.')[-1]: self._get_full_repository_uri(namespace, service_id, env_tag) for env_tag in env_tags}
+        refs = [self._get_full_repository_uri(namespace, service_id, ref_tag) for ref_tag in ref_tags]
+
+        # It is possible multiple ref tags can occur if images are published at new git refs with
+        # no image changes, deal with it gracefully - just get the first
+        if len(refs) < 1:
+            raise RuntimeError(f"No matching ref tags found for {repository_name}:{tag}!")
+        ref = refs[0]
+
+        return {
+            'registry_id': image_details['registryId'],
+            'repository_name': image_details['repositoryName'],
+            'image_digest': image_details['imageDigest'],
+            'is_latest': is_latest,
+            'service_id': service_id,
+            'envs': envs,
+            'ref': ref
+        }
 
     def retag_image(self, namespace, service_id, tag, new_tag, dry_run=False):
         repository_name = Ecr._get_repository_name(namespace, service_id)

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -74,7 +74,12 @@ class Ecr:
         ref_tags = [image for image in image_details['imageTags'] if image.startswith("ref.")]
         env_tags = [image for image in image_details['imageTags'] if image.startswith("env.")]
 
-        envs = {env_tag.split('.')[-1]: self._get_full_repository_uri(namespace, service_id, env_tag) for env_tag in env_tags}
+        envs = {env_tag.split('.')[-1]: self._get_full_repository_uri(
+            namespace,
+            service_id,
+            env_tag
+        ) for env_tag in env_tags}
+
         refs = [self._get_full_repository_uri(namespace, service_id, ref_tag) for ref_tag in ref_tags]
 
         # It is possible multiple ref tags can occur if images are published at new git refs with


### PR DESCRIPTION
If provided images described in `.wellcome-project` will be used instead of referring to SSM.

This lays the groundwork to link services to images in configuration to allow for ECS deployment from the tool.

For example:
```json
{
    "mets_adapter":  {
        "environments":  [
            {
                "id": "stage",
                "name": "Staging"
            },
            {
                "id": "prod",
                "name": "Production"
            }
        ],
        "image_repositories": [
            {
                "id": "mets_adapter",
                "namespace" : "uk.ac.wellcome",
                "account_id": "760097843905"
            }
        ],
        "name": "METS Adapter",
        "role_arn": "arn:aws:iam::760097843905:role/platform-ci",
        "aws_region_name": "eu-west-1",
        "github_repository": "wellcometrust/catalogue"
    }
}
```
`namespace` & `account_id` are optional and will use defaults if not provided.

This should not break backwards compatibility.