### PR TITLE
Allow ECS deployment

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Auto-detect ECS services and ask to deploy if configuration is available.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -327,8 +327,9 @@ def deploy(ctx, release_id, environment_id, namespace, description):
         )
 
         click.echo(click.style(
-            f"*** {image_id}: Retagged image {image_id}:{old_tag} to {image_id}:{new_tag}", fg="yellow")
-        )
+            f"*** {image_id}: Retagged image {image_id}:{old_tag} to {image_id}:{new_tag}",
+            fg="yellow"
+        ))
         click.echo("")
 
     image_repositories = project.get('image_repositories')
@@ -354,13 +355,19 @@ def deploy(ctx, release_id, environment_id, namespace, description):
         click.echo("")
         click.confirm(click.style("Attempt ECS deployment?", fg="green", bold=True), abort=True)
 
-        deployments = [ecs.redeploy_service(service['clusterArn'], service['serviceArn']) for service in matched_services]
+        deployments = [ecs.redeploy_service(
+            service['clusterArn'],
+            service['serviceArn']
+        ) for service in matched_services]
 
         click.echo(click.style(f"*** {image_id}: ECS Services deployed: {service_arns}", fg="yellow"))
         click.echo(pprint(deployments))
 
     else:
-        click.echo(click.style(f"*** {image_id}: No matching ECS Service discovered, manual redeployment required", fg="yellow"))
+        click.echo(click.style(
+            f"*** {image_id}: No matching ECS Service discovered, manual redeployment required",
+            fg="yellow"
+        ))
 
     if dry_run:
         click.echo("dry-run, not created.")

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -350,7 +350,10 @@ def _deploy(project, role_arn, dry_run, confirm, release_id, environment_id, nam
             for deployment in deployments:
                 service_arn = deployment['service_arn']
                 deployment_id = deployment['deployment_id']
-                click.echo(click.style(f"{image_id}: ECS Service deployed {service_arn} to {deployment_id}", fg="bright_yellow"))
+                click.echo(click.style(
+                    f"{image_id}: ECS Service deployed {service_arn} to {deployment_id}",
+                    fg="bright_yellow"
+                ))
 
     if dry_run:
         click.echo("dry-run, not created.")
@@ -456,6 +459,7 @@ def _prepare(project, role_arn, dry_run, from_label, service_id, release_descrip
         click.echo("dry-run, not created.")
 
     return release['release_id']
+
 
 @cli.command()
 @click.option('--from-label', prompt="Label to base release upon",

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -249,8 +249,9 @@ def initialise(ctx, project_name, environment_id, environment_name):
 @click.option("--namespace", default=DEFAULT_ECR_NAMESPACE, show_default=True)
 @click.option('--description', prompt="Enter a description for this deployment",
               help="A description of this deployment", default="No description provided")
+@click.option('--confirm', '-y', is_flag=True, help="Non-interactive deployment confirmation")
 @click.pass_context
-def deploy(ctx, release_id, environment_id, namespace, description):
+def deploy(ctx, release_id, environment_id, namespace, description, confirm):
     project = ctx.obj['project']
     role_arn = ctx.obj['role_arn']
     dry_run = ctx.obj['dry_run']
@@ -283,11 +284,33 @@ def deploy(ctx, release_id, environment_id, namespace, description):
     click.echo(click.style(f"Date created: {release['date_created']}", fg="yellow"))
 
     click.echo("")
-    for service, image in release['images'].items():
-        click.echo(click.style(f"{service}: {image}", fg="bright_yellow"))
+    matched_services = {}
+    for image_id, image_uri in release['images'].items():
+        click.echo(click.style(f"{image_id}: {image_uri}", fg="bright_yellow"))
 
-    click.echo("")
-    click.confirm(click.style("Create deployment?", fg="green", bold=True), abort=True)
+        image_repositories = project.get('image_repositories')
+
+        # Naively assume service name matches image id
+        service_ids = [image_id]
+
+        # Attempt to match deployment image id to config and override service_ids
+        if image_repositories:
+            matched_image_ids = [image for image in image_repositories if image['id'] == image_id]
+
+            if matched_image_ids:
+                matched_image_id = matched_image_ids[0]
+                service_ids = matched_image_id.get('services')
+
+        # Attempt to match service ids to ECS services
+        available_services = [ecs.get_service(service_id, environment_id) for service_id in service_ids]
+        if available_services:
+            matched_services[image_id] = available_services
+            service_arns = [service['serviceArn'] for service in available_services]
+            click.echo(click.style(f"{image_id}: ECS Services discovered: {service_arns}", fg="bright_yellow"))
+
+    if not confirm:
+        click.echo("")
+        click.confirm(click.style("Create deployment?", fg="green", bold=True), abort=True)
 
     caller_identity = user_details.caller_identity(underlying=True)
     deployment = create_deployment(environment, caller_identity['arn'], description)
@@ -298,12 +321,7 @@ def deploy(ctx, release_id, environment_id, namespace, description):
     click.echo(click.style(f"Requested by: {deployment['requested_by']}", fg="yellow"))
     click.echo(click.style(f"Date created: {deployment['date_created']}", fg="yellow"))
 
-    releases_store.add_deployment(
-        release_id=release['release_id'],
-        deployment=deployment,
-        dry_run=dry_run
-    )
-
+    click.echo("")
     for image_id, image_name in release['images'].items():
         ssm_path = parameter_store.update_ssm(
             service_id=image_id,
@@ -312,13 +330,12 @@ def deploy(ctx, release_id, environment_id, namespace, description):
             dry_run=dry_run
         )
 
-        click.echo("")
-        click.echo(click.style(f"*** {image_id}: Updated SSM path {ssm_path} to {image_name}", fg="yellow"))
+        click.echo(click.style(f"{image_id}: Updated SSM path {ssm_path} to {image_name}", fg="bright_yellow"))
 
         old_tag = image_name.split(":")[-1]
         new_tag = f"env.{environment_id}"
 
-        ecr.retag_image(
+        result = ecr.retag_image(
             namespace=namespace,
             service_id=image_id,
             tag=old_tag,
@@ -326,83 +343,32 @@ def deploy(ctx, release_id, environment_id, namespace, description):
             dry_run=dry_run
         )
 
-        click.echo(click.style(
-            f"*** {image_id}: Retagged image {image_id}:{old_tag} to {image_id}:{new_tag}",
-            fg="yellow"
-        ))
-        click.echo("")
+        if result['status'] == 'success':
+            click.echo(click.style(
+                f"{image_id}: Re-tagged image {image_id}:{old_tag} to {image_id}:{new_tag}",
+                fg="bright_yellow"
+            ))
+        else:
+            click.echo(click.style(
+                f"{image_id}: Already tagged image {image_id}:{old_tag} to {image_id}:{new_tag} (nothing to do)",
+                fg="yellow"
+            ))
 
-    image_repositories = project.get('image_repositories')
+        if image_id in matched_services:
+            deployments = [ecs.redeploy_service(
+                service['clusterArn'],
+                service['serviceArn']
+            ) for service in matched_services.get(image_id)]
 
-    # Naively assume service name matches image name
-    service_ids = [image_id]
-
-    # Attempt to match deployment image id to config and override service_ids
-    if image_repositories:
-        matched_image_ids = [image for image in image_repositories if image['id'] == image_id]
-
-        if matched_image_ids:
-            matched_image_id = matched_image_ids[0]
-            service_ids = matched_image_id.get('services')
-
-    # Attempt to match service ids to ECS services
-    matched_services = [ecs.get_service(service_id, environment_id) for service_id in service_ids]
-
-    if matched_services:
-        service_arns = [service['serviceArn'] for service in matched_services]
-        click.echo(click.style(f"*** {image_id}: ECS Services discovered: {service_arns}", fg="bright_yellow"))
-
-        click.echo("")
-        click.confirm(click.style("Attempt ECS deployment?", fg="green", bold=True), abort=True)
-
-        deployments = [ecs.redeploy_service(
-            service['clusterArn'],
-            service['serviceArn']
-        ) for service in matched_services]
-
-        click.echo(click.style(f"*** {image_id}: ECS Services deployed: {service_arns}", fg="yellow"))
-        click.echo(pprint(deployments))
-
-    else:
-        click.echo(click.style(
-            f"*** {image_id}: No matching ECS Service discovered, manual redeployment required",
-            fg="yellow"
-        ))
-
-    image_repositories = project.get('image_repositories')
-
-    # Naively assume service name matches image name
-    service_ids = [image_id]
-
-    # Attempt to match deployment image id to config and override service_ids
-    if image_repositories:
-        matched_image_ids = [image for image in image_repositories if image['id'] == image_id]
-
-        if matched_image_ids:
-            matched_image_id = matched_image_ids[0]
-            service_ids = matched_image_id.get('services')
-
-    # Attempt to match service ids to ECS services
-    matched_services = [ecs.get_service(service_id, environment_id) for service_id in service_ids]
-
-    if matched_services:
-        service_arns = [service['serviceArn'] for service in matched_services]
-        click.echo(click.style(f"*** {image_id}: ECS Services discovered: {service_arns}", fg="bright_yellow"))
-
-        click.echo("")
-        click.confirm(click.style("Attempt ECS deployment?", fg="green", bold=True), abort=True)
-
-        deployments = [ecs.redeploy_service(service['clusterArn'], service['serviceArn']) for service in matched_services]
-
-        click.echo(click.style(f"*** {image_id}: ECS Services deployed: {service_arns}", fg="yellow"))
-        click.echo(pprint(deployments))
-
-    else:
-        click.echo(click.style(f"*** {image_id}: No matching ECS Service discovered, manual redeployment required", fg="yellow"))
+            for deployment in deployments:
+                service_arn = deployment['service_arn']
+                deployment_id = deployment['deployment_id']
+                click.echo(click.style(f"{image_id}: ECS Service deployed {service_arn} to {deployment_id}", fg="bright_yellow"))
 
     if dry_run:
         click.echo("dry-run, not created.")
 
+    click.echo("")
     click.echo(click.style(f"Deployed {image_id} to {new_tag}", fg="green"))
 
 

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -7,6 +7,7 @@ from pprint import pprint
 
 from .commands import configure_aws_profile
 from .ecr import Ecr
+from .ecs import Ecs
 from .model import create_deployment, create_release
 from .project_config import load, save, exists, get_environments_lookup
 
@@ -260,6 +261,7 @@ def deploy(ctx, release_id, environment_id, namespace, description):
     region_id = project['aws_region_name']
 
     ecr = Ecr(account_id, region_id, role_arn)
+    ecs = Ecs(account_id, region_id, role_arn)
 
     user_details = Iam(role_arn)
 
@@ -302,37 +304,68 @@ def deploy(ctx, release_id, environment_id, namespace, description):
         dry_run=dry_run
     )
 
-    for service_id, image_name in release['images'].items():
+    for image_id, image_name in release['images'].items():
         ssm_path = parameter_store.update_ssm(
-            service_id=service_id,
+            service_id=image_id,
             label=environment_id,
             image_name=image_name,
             dry_run=dry_run
         )
 
         click.echo("")
-        click.echo(click.style(f"*** {service_id}: Updated SSM path {ssm_path} to {image_name}", fg="yellow"))
+        click.echo(click.style(f"*** {image_id}: Updated SSM path {ssm_path} to {image_name}", fg="yellow"))
 
         old_tag = image_name.split(":")[-1]
         new_tag = f"env.{environment_id}"
 
         ecr.retag_image(
             namespace=namespace,
-            service_id=service_id,
+            service_id=image_id,
             tag=old_tag,
             new_tag=new_tag,
             dry_run=dry_run
         )
 
         click.echo(click.style(
-            f"*** {service_id}: Retagged image {service_id}:{old_tag} to {service_id}:{new_tag}", fg="yellow")
+            f"*** {image_id}: Retagged image {image_id}:{old_tag} to {image_id}:{new_tag}", fg="yellow")
         )
         click.echo("")
+
+    image_repositories = project.get('image_repositories')
+
+    # Naively assume service name matches image name
+    service_ids = [image_id]
+
+    # Attempt to match deployment image id to config and override service_ids
+    if image_repositories:
+        matched_image_ids = [image for image in image_repositories if image['id'] == image_id]
+
+        if matched_image_ids:
+            matched_image_id = matched_image_ids[0]
+            service_ids = matched_image_id.get('services')
+
+    # Attempt to match service ids to ECS services
+    matched_services = [ecs.get_service(service_id, environment_id) for service_id in service_ids]
+
+    if matched_services:
+        service_arns = [service['serviceArn'] for service in matched_services]
+        click.echo(click.style(f"*** {image_id}: ECS Services discovered: {service_arns}", fg="bright_yellow"))
+
+        click.echo("")
+        click.confirm(click.style("Attempt ECS deployment?", fg="green", bold=True), abort=True)
+
+        deployments = [ecs.redeploy_service(service['clusterArn'], service['serviceArn']) for service in matched_services]
+
+        click.echo(click.style(f"*** {image_id}: ECS Services deployed: {service_arns}", fg="yellow"))
+        click.echo(pprint(deployments))
+
+    else:
+        click.echo(click.style(f"*** {image_id}: No matching ECS Service discovered, manual redeployment required", fg="yellow"))
 
     if dry_run:
         click.echo("dry-run, not created.")
 
-    click.echo(click.style(f"Deployed {service_id} to {new_tag}", fg="green"))
+    click.echo(click.style(f"Deployed {image_id} to {new_tag}", fg="green"))
 
 
 @cli.command()

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -130,7 +130,9 @@ class Ecr:
                 if not e.response['Error']['Code'] == 'ImageAlreadyExistsException':
                     raise e
                 else:
-                    print(f"Image {tag} already tagged {new_tag}: nothing to do")
+                    return {'status': 'noop'}
+
+        return {'status': 'success'}
 
     def login(self, profile_name=None):
         base = ['aws', 'ecr', 'get-login']

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -129,6 +129,8 @@ class Ecr:
                 # Matching tag & digest already exists (nothing to do)
                 if not e.response['Error']['Code'] == 'ImageAlreadyExistsException':
                     raise e
+                else:
+                    print(f"Image {tag} already tagged {new_tag}: nothing to do")
 
     def login(self, profile_name=None):
         base = ['aws', 'ecr', 'get-login']

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -1,10 +1,6 @@
 import itertools
 
 from .iam import Iam
-<<<<<<< HEAD
-=======
-from pprint import pprint
->>>>>>> 378ca9888db9385feb0b3fcd38420afc0f3e3ddf
 
 
 class Ecs:

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -1,0 +1,108 @@
+import itertools
+
+from .iam import Iam
+from pprint import pprint
+
+
+class Ecs:
+    def __init__(self, account_id, region_id, role_arn=None):
+        self.account_id = account_id
+        self.region_id = region_id
+        self.session = Iam.get_session("ReleaseToolEcs", role_arn)
+        self.ecs = self.session.client('ecs')
+        self.described_services = []
+        self._load_described_services()
+
+    def _load_described_services(self):
+        service_arns_iterator = self._iterate_all_service()
+
+        services = {}
+        for cluster_arn, service_arn in service_arns_iterator:
+            if cluster_arn in services:
+                services[cluster_arn].append(service_arn)
+            else:
+                services[cluster_arn] = [service_arn]
+
+        for cluster_arn, service_arns in services.items():
+            for service_arns_chunk in Ecs._chunked_iterable(service_arns, 10):
+                response = self.ecs.describe_services(
+                    cluster=cluster_arn,
+                    services=service_arns_chunk,
+                    include=[
+                        'TAGS',
+                    ]
+                )
+
+                for service_details in response['services']:
+                    self.described_services.append(service_details)
+
+    # Credit to https://alexwlchan.net/2018/12/iterating-in-fixed-size-chunks/
+    @staticmethod
+    def _chunked_iterable(iterable, size):
+        it = iter(iterable)
+        while True:
+            chunk = tuple(itertools.islice(it, size))
+            if not chunk:
+                break
+            yield chunk
+
+    def _iterate_all_service(self):
+        cluster_paginator = self.ecs.get_paginator('list_clusters')
+        cluster_iterator = cluster_paginator.paginate()
+        service_paginator = self.ecs.get_paginator('list_services')
+
+        for cluster_response in cluster_iterator:
+            for cluster_arn in cluster_response['clusterArns']:
+                service_iterator = service_paginator.paginate(
+                    cluster=cluster_arn
+                )
+
+                for service_response in service_iterator:
+                    for service_arn in service_response['serviceArns']:
+                        yield cluster_arn, service_arn
+
+    def redeploy_service(self, cluster_arn, service_arn):
+        response = self.ecs.update_service(
+            cluster=cluster_arn,
+            service=service_arn,
+            forceNewDeployment=True
+        )
+
+        return {
+            'cluster_arn': response['service']['clusterArn'],
+            'service_arn': response['service']['serviceArn'],
+            'deployment_id': response['service']['deployments'][0]['id']
+        }
+
+    def get_service(self, service_id, env):
+        def _match_deployment_tags(service, desired_service_tag, desired_env_tag):
+            tags = service.get('tags')
+
+            if not tags:
+                return False
+
+            env_tags = [tag for tag in tags if tag.get('key') == 'deployment:env']
+            service_tags = [tag for tag in tags if tag.get('key') == 'deployment:service']
+
+            env_tag = None
+            if env_tags:
+                env_tag = env_tags[0]['value']
+
+            service_tag = None
+            if service_tags:
+                service_tag = service_tags[0]['value']
+
+            if env_tag == desired_env_tag and service_tag == desired_service_tag:
+                return True
+            else:
+                return False
+
+        matched_services = [service for service in self.described_services if _match_deployment_tags(service, service_id, env)]
+
+        if len(matched_services) > 1:
+            raise RuntimeError(f"Multiple matching services found for {service_id}/{env}!")
+
+        if len(matched_services) == 0:
+            return None
+        else:
+            return matched_services[0]

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -1,7 +1,6 @@
 import itertools
 
 from .iam import Iam
-from pprint import pprint
 
 
 class Ecs:
@@ -97,7 +96,9 @@ class Ecs:
             else:
                 return False
 
-        matched_services = [service for service in self.described_services if _match_deployment_tags(service, service_id, env)]
+        matched_services = [service for service in self.described_services if _match_deployment_tags(
+            service, service_id, env
+        )]
 
         if len(matched_services) > 1:
             raise RuntimeError(f"Multiple matching services found for {service_id}/{env}!")

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -100,7 +100,6 @@ class Ecs:
             service, service_id, env
         )]
 
-
         if len(matched_services) > 1:
             raise RuntimeError(f"Multiple matching services found for {service_id}/{env}!")
 


### PR DESCRIPTION
Attempt to match ECS services to deployment config, if a match is found ask to deploy in ECS.

The added (optional) "services" param on image repository is required to match services that have a different name from their image id.

`services` is a list as a single image can have multiple target services within an enviroment.

`.wellcome_project` configuration:

```json
{
    "mets_adapter":  {
        "environments":  [
            {
                "id": "prod",
                "name": "Production"
            }
        ],
        "image_repositories": [
            {
                "id": "mets_adapter",
                "namespace" : "uk.ac.wellcome",
                "account_id": "760097843905",
                "services": ["mets-adapter"]
            }
        ],
        "name": "METS Adapter",
        "role_arn": "arn:aws:iam::760097843905:role/platform-ci",
        "aws_region_name": "eu-west-1",
        "github_repository": "wellcometrust/catalogue",
        "tf_stack_root": "mets_adapter/terraform"
    }
}
```

Images passed to ECS services should use the following convention, the tag being `env.foo` where foo is the environment id specified in `.wellcome_project`.

```tf
locals {
  mets_adapter_image = "${aws_ecr_repository.mets_adapter.repository_url}:env.prod"
}
```

In action:

![ecs_deploy](https://user-images.githubusercontent.com/953792/87552370-80267c80-c6a9-11ea-9ee4-374758bbe578.gif)

This should not disrupt existing deployment using terraform.
