### PR TITLE
Do some pretty-printing in the "prepare" step

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+When running the ``prepare`` command, show a table of services, the Git commit of the previous and new release, and the commit message associated with the new images.

--- a/src/deploy/git.py
+++ b/src/deploy/git.py
@@ -3,7 +3,7 @@ import functools
 from .commands import cmd
 
 
-@functools.lru_cache
+@functools.lru_cache()
 def log(commit_id):
     """
     Returns a one-line log for a given commit ID.

--- a/src/deploy/git.py
+++ b/src/deploy/git.py
@@ -1,0 +1,11 @@
+import functools
+
+from .commands import cmd
+
+
+@functools.lru_cache
+def log(commit_id):
+    """
+    Returns a one-line log for a given commit ID.
+    """
+    return cmd("git", "show", "-s", "--format=%B", commit_id)

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -243,12 +243,15 @@ class Project:
         if not release_images:
             raise RuntimeError(f"No images found for {self.id}/{from_label}")
 
-        release = self._create_release(
+        previous_release = self.releases_store.get_latest_release()
+
+        new_release = self._create_release(
             description=description,
             images=release_images
         )
+        self.releases_store.put_release(new_release)
 
-        return self.releases_store.put_release(release)
+        return {"previous_release": previous_release, "new_release": new_release}
 
     def deploy(self, release_id, environment_id, namespace, description):
         release = self.get_release(release_id)


### PR DESCRIPTION
I'll extend this to the "deploy" step at some point, but this is still a step forward IMO:

Before:

![Screenshot 2020-07-20 at 15 19 32](https://user-images.githubusercontent.com/301220/87948304-6ebfe480-ca9c-11ea-9c25-95850b38f061.png)

After:

![Screenshot 2020-07-20 at 15 11 15](https://user-images.githubusercontent.com/301220/87948150-3cae8280-ca9c-11ea-89d2-29b447d46650.png)