### PR TITLE
Fix a bug in the `prepare` command with missing Git commits

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a bug in the ``prepare`` command that would throw a subprocess.CalledProcessError if your release included a Git commit that you didn't have locally.

--- a/src/deploy/git.py
+++ b/src/deploy/git.py
@@ -1,4 +1,5 @@
 import functools
+import subprocess
 
 from .commands import cmd
 
@@ -8,4 +9,11 @@ def log(commit_id):
     """
     Returns a one-line log for a given commit ID.
     """
-    return cmd("git", "show", "-s", "--format=%B", commit_id)
+    try:
+        cmd("git", "fetch", "origin")
+
+        # %s = subject, the first line of the commit
+        # See https://git-scm.com/docs/pretty-formats
+        return cmd("git", "show", "-s", "--format=%s", commit_id)
+    except subprocess.CalledProcessError:
+        return ""


### PR DESCRIPTION
If you run `git show` for a commit that isn't present (e.g. a merge commit created on GitHub), you'd get an error from the `prepare` command:

    fatal: ambiguous argument '666929a': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'

This patch does a `git fetch` (not a `pull`) to get all the commits on the remote, and also handles a missing commit more gracefully.

Also tweak the formatting so you actually get the subject line, and not the entire commit body (oops).