### PR TITLE
Minor refactoring and cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: false
-python: 3.6
+python: 3.7
 services:
 - docker
 branches:

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Some internal refactoring that should have no user visible effect.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -167,7 +167,7 @@ def _deploy(project, release_id, environment_id, description, confirm=True):
     headers = ["image ID", "services"]
 
     for image_id, services in sorted(ecs_services.items()):
-        service_names = [serv['ecs_response']["serviceArn"].split("/")[-1] for serv in services]
+        service_names = [service['response']["serviceArn"].split("/")[-1] for service in services]
         rows.append([image_id, ", ".join(sorted(service_names))])
 
     print("ECS services discovered:\n")

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -157,7 +157,10 @@ def _deploy(project, release_id, environment_id, description, confirm=True):
     click.echo(click.style(f"Requested by: {release['requested_by']}", fg="yellow"))
     click.echo(click.style(f"Date created: {release['date_created']}", fg="yellow"))
 
-    ecs_services = project.get_ecs_services(release_id, environment_id)
+    ecs_services = project.get_ecs_services(
+        release=release,
+        environment_id=environment_id
+    )
 
     rows = []
 

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -62,9 +62,9 @@ class Ecs:
             'deployment_id': response['service']['deployments'][0]['id']
         }
 
-    def get_service(self, service_id, env):
+    def find_matching_service(self, *, service_id, environment_id):
         """
-        Given a service ID (e.g. bag-unpacker) and an environment (e.g. prod),
+        Given a service (e.g. bag-unpacker) and an environment (e.g. prod),
         return the unique matching service.
         """
         def _has_matching_tags(service):
@@ -72,7 +72,7 @@ class Ecs:
 
             return (
                 service_tags.get("deployment:service") == service_id and
-                service_tags.get("deployment:env") == env
+                service_tags.get("deployment:env") == environment_id
             )
 
         matched_services = [
@@ -82,7 +82,10 @@ class Ecs:
         ]
 
         if len(matched_services) > 1:
-            raise RuntimeError(f"Multiple matching services found for {service_id}/{env}: ({matched_services}!")
+            raise RuntimeError(
+                f"Multiple matching services found for {service_id}/{environment_id}: "
+                f"({matched_services})!"
+            )
 
         if len(matched_services) == 0:
             return None

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -4,7 +4,7 @@ from .tags import parse_aws_tags
 
 
 class Ecs:
-    def __init__(self, account_id, region_name, role_arn):
+    def __init__(self, region_name, role_arn):
         session = Iam.get_session(
             session_name="ReleaseToolEcs",
             role_arn=role_arn,

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -5,14 +5,12 @@ from .tags import parse_aws_tags
 
 class Ecs:
     def __init__(self, account_id, region_name, role_arn):
-        self.account_id = account_id
-        self.region_name = region_name
-        self.session = Iam.get_session(
+        session = Iam.get_session(
             session_name="ReleaseToolEcs",
             role_arn=role_arn,
             region_name=region_name
         )
-        self.ecs = self.session.client('ecs')
+        self.ecs = session.client('ecs')
         self.described_services = []
         self._load_described_services()
 

--- a/src/deploy/iterators.py
+++ b/src/deploy/iterators.py
@@ -1,0 +1,17 @@
+import itertools
+
+
+def chunked_iterable(iterable, *, size):
+    """
+    Generate the entries in ``iterable`` in chunks of size ``size``.
+
+    e.g. chunked_iterable([1, 2, 3, 4, 5], 2) -> [1, 2], [3, 4], [5]
+
+    Taken from https://alexwlchan.net/2018/12/iterating-in-fixed-size-chunks/
+    """
+    it = iter(iterable)
+    while True:
+        chunk = tuple(itertools.islice(it, size))
+        if not chunk:
+            break
+        yield chunk

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -349,7 +349,7 @@ class Project:
                 image_id=image_id,
                 image_name=image_name
             )
-            
+
             ecs_deployments = []
             if image_id in matched_services:
 

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -119,7 +119,6 @@ class Project:
 
     def _ecs(self, account_id=None, region_name=None, role_arn=None):
         return Ecs(
-            account_id=account_id or self.account_id,
             region_name=region_name or self.region_name,
             role_arn=role_arn or self.role_arn
         )
@@ -183,7 +182,6 @@ class Project:
     def get_ecs_services(self, release, environment_id):
         def _get_service(service):
             ecs = self._ecs(
-                account_id=service.get('account_id'),
                 region_name=service.get('region_name'),
                 role_arn=service.get('role_arn')
             )

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -180,9 +180,7 @@ class Project:
         else:
             return self.releases_store.get_release(release_id)
 
-    def get_ecs_services(self, release_id, environment_id):
-        release = self.get_release(release_id)
-
+    def get_ecs_services(self, release, environment_id):
         def _get_service(service):
             ecs_service = self._ecs(
                 account_id=service.get('account_id'),
@@ -291,7 +289,10 @@ class Project:
 
     def deploy(self, release_id, environment_id, description):
         release = self.get_release(release_id)
-        matched_services = self.get_ecs_services(release_id, environment_id)
+        matched_services = self.get_ecs_services(
+            release=release,
+            environment_id=environment_id
+        )
 
         # Force check for valid environment
         _ = self.get_environment(environment_id)

--- a/src/deploy/tags.py
+++ b/src/deploy/tags.py
@@ -1,0 +1,22 @@
+def parse_aws_tags(tags):
+    """
+    When you get the tags on an AWS resource from the API, they are in the form
+
+        [{"key": "KEY1", "value": "VALUE1"},
+         {"key": "KEY2", "value": "VALUE2"},
+         ...]
+
+    This function converts them into a Python-style dict().
+
+    """
+    result = {}
+
+    for aws_tag in tags:
+        assert isinstance(aws_tag, dict)
+        assert aws_tag.keys() == {"key", "value"}
+
+        assert aws_tag["key"] not in result, f"Duplicate key in tags: {aws_tag['key']}"
+
+        result[aws_tag["key"]] = aws_tag["value"]
+
+    return result

--- a/tests/test_iterators.py
+++ b/tests/test_iterators.py
@@ -1,0 +1,18 @@
+from deploy.iterators import chunked_iterable
+
+
+def test_chunked_iterable():
+    numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+    print(list(chunked_iterable(numbers, size=3)))
+    assert list(chunked_iterable(numbers, size=3)) == [
+        (1, 2, 3),
+        (4, 5, 6),
+        (7, 8, 9),
+        (10,),
+    ]
+
+    assert list(chunked_iterable(numbers, size=5)) == [
+        (1, 2, 3, 4, 5),
+        (6, 7, 8, 9, 10),
+    ]

--- a/tests/test_iterators.py
+++ b/tests/test_iterators.py
@@ -4,7 +4,6 @@ from deploy.iterators import chunked_iterable
 def test_chunked_iterable():
     numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
-    print(list(chunked_iterable(numbers, size=3)))
     assert list(chunked_iterable(numbers, size=3)) == [
         (1, 2, 3),
         (4, 5, 6),

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,20 @@
+import pytest
+
+from deploy.tags import parse_aws_tags
+
+
+@pytest.mark.parametrize(
+    "aws_tags, expected_tags",
+    [
+        ([], {}),
+        (
+            [
+                {"key": "deployment:env", "value": "prod"},
+                {"key": "deployment:service", "value": "bag-unpacker"},
+            ],
+            {"deployment:env": "prod", "deployment:service": "bag-unpacker"},
+        ),
+    ],
+)
+def test_parse_aws_tags(aws_tags, expected_tags):
+    assert parse_aws_tags(aws_tags) == expected_tags

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py36, lint
+envlist = py37, lint
 
 [testenv]
-basepython = python3.6
+basepython = python3.7
 deps =
     -r{toxinidir}/test_requirements.txt
 commands =


### PR DESCRIPTION
I was looking at whether we could skip doing an ECS deployment if the ECR retagging operation was a no-op (because interrupting something like a replication could be quite disruptive).

While following the code through, I tugged on a bunch of threads to decompose it into some simpler, more documented functions.