### PR TITLE
Remove an unused (and unspecified) param from release_deploy

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a bug that caused the `release-deploy` command to fail.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -304,7 +304,7 @@ def prepare(ctx, from_label, description):
 @click.option('--description', prompt="Enter a description for this deployment",
               help="A description of this deployment", default="No description provided")
 @click.pass_context
-def release_deploy(ctx, from_label, environment_id, namespace, description):
+def release_deploy(ctx, from_label, environment_id, description):
     project = ctx.obj['project']
     confirm = ctx.obj['confirm']
 


### PR DESCRIPTION
Previously it would throw an error if you tried to run 'release-deploy':

    Traceback (most recent call last):
      File "/usr/local/bin/weco-deploy", line 11, in <module>
        load_entry_point('weco-deploy', 'console_scripts', 'weco-deploy')()
      File "/Users/alexwlchan/repos/weco-deploy/src/deploy/deploy.py", line 402, in main
        cli()
      File "/Users/alexwlchan/Library/Python/3.8/lib/python/site-packages/click/core.py", line 829, in __call__
        return self.main(*args, **kwargs)
      File "/Users/alexwlchan/Library/Python/3.8/lib/python/site-packages/click/core.py", line 782, in main
        rv = self.invoke(ctx)
      File "/Users/alexwlchan/Library/Python/3.8/lib/python/site-packages/click/core.py", line 1259, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
      File "/Users/alexwlchan/Library/Python/3.8/lib/python/site-packages/click/core.py", line 1066, in invoke
        return ctx.invoke(self.callback, **ctx.params)
      File "/Users/alexwlchan/Library/Python/3.8/lib/python/site-packages/click/core.py", line 610, in invoke
        return callback(*args, **kwargs)
      File "/Users/alexwlchan/Library/Python/3.8/lib/python/site-packages/click/decorators.py", line 21, in new_func
        return f(get_current_context(), *args, **kwargs)
    TypeError: release_deploy() missing 1 required positional argument: 'namespace'

This argument is now passed around in the `ctx` object.