### PR TITLE
Handle deploying images which do not currently have an active service

### DIFF
--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -167,10 +167,7 @@ def _deploy(project, release_id, environment_id, description, confirm=True):
     headers = ["image ID", "services"]
 
     def _get_service_name(service):
-        if service['response']:
-            return click.style(service['response']["serviceArn"].split("/")[-1], fg="green")
-        else:
-            return click.style("Not found", fg="red")
+        return click.style(service['response']["serviceArn"].split("/")[-1], fg="green")
 
     for image_id, services in sorted(ecs_services.items()):
         service_names = [_get_service_name(service) for service in services]

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -207,7 +207,7 @@ class Project:
                 services = matched_image.get('services', [])
 
                 available_services = [_get_service(service) for service in services]
-                available_services = [service for service in available_services if service]
+                available_services = [service for service in available_services if service["response"]]
 
             if available_services:
                 matched_services[image_id] = available_services


### PR DESCRIPTION
I started doing this as adding a feature but it looks like it was always intended to be able to do this and there was a bug, as https://github.com/wellcomecollection/weco-deploy/compare/deploy-to-nowhere?expand=1#diff-507e85bd7b4c730fe41fb4eeef25b929L210 would never have been falsy...