### PR TITLE
Emphasise any changes (or lack of) in 'weco-deploy release'

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix the printing of coloured tables in the weco-deploy output.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,0 @@
-RELEASE_TYPE: patch
-
-Fix the printing of coloured tables in the weco-deploy output.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix the printing of coloured tables in the weco-deploy output.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -261,10 +261,8 @@ def _prepare(project, from_label, description):
         rows.append([
             service,
             prev_git_commit,
-            "-"
-            if new_git_commit == prev_git_commit
-            else click.style(new_git_commit, fg="green"),
-            git.log(new_git_commit),
+            "-" if new_git_commit == prev_git_commit else new_git_commit,
+            "-" if new_git_commit == prev_git_commit else git.log(new_git_commit),
         ])
 
     click.echo(tabulate(rows, headers=headers))

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -261,7 +261,7 @@ def _prepare(project, from_label, description):
         rows.append([
             service,
             prev_git_commit,
-            new_git_commit
+            "-"
             if new_git_commit == prev_git_commit
             else click.style(new_git_commit, fg="green"),
             git.log(new_git_commit),

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -175,7 +175,7 @@ def _deploy(project, release_id, environment_id, description, confirm=True):
 
     click.echo("")
     click.echo(click.style("ECS services discovered:\n", fg="yellow", underline=True))
-    click.echo(click.style(tabulate(rows, headers=headers), fg="yellow"))
+    click.echo(tabulate(rows, headers=headers))
 
     if not confirm:
         click.echo("")
@@ -267,7 +267,7 @@ def _prepare(project, from_label, description):
             git.log(new_git_commit),
         ])
 
-    click.echo(click.style(tabulate(rows, headers=headers), fg="yellow"))
+    click.echo(tabulate(rows, headers=headers))
 
     click.echo("")
     click.echo(click.style(f"Created release {new_release['release_id']}", fg="bright_green"))


### PR DESCRIPTION
This is to emphasise any changes made since the previous release (or lack of, as appropriate). The table will now only highlight any changes that have been made.

Before:

![Screenshot 2020-09-17 at 11 23 35](https://user-images.githubusercontent.com/301220/93458639-78b56680-f8d8-11ea-812b-36d80db84b88.png)

After:

![Screenshot 2020-09-17 at 11 39 47](https://user-images.githubusercontent.com/301220/93459998-87048200-f8da-11ea-8ee2-0f9f0d8c5115.png)
