### PR TITLE
Only deploy ECS services that have actually changed

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+When deploying services, weco-deploy prints a simpler summary of the changes.
+It also skips the ECS deployment if the ECR image tags for a service have not changed.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -188,18 +188,31 @@ def _deploy(project, release_id, environment_id, description, confirm=True):
     click.echo(click.style(f"Requested by: {result['requested_by']}", fg="yellow"))
     click.echo(click.style(f"Date created: {result['date_created']}", fg="yellow"))
     click.echo("")
-    for image_id, summary in result['details'].items():
-        click.echo(click.style(f"Summary for {image_id}", fg="bright_yellow"))
-        click.echo(click.style(
-            f"{image_id}: ECR Updated {summary['tag_result']['source']} to {summary['tag_result']['target']}",
-            fg="yellow"
-        ))
 
-        for ecs_deployment in summary['ecs_deployments']:
-            click.echo(click.style(
-                f"{image_id}: ECS Deployed {ecs_deployment['service_arn']} to {ecs_deployment['deployment_id']}",
-                fg="yellow"
-            ))
+    rows = []
+
+    headers = ['image ID', 'summary of changes']
+    for image_id, summary in result['details'].items():
+        if summary['tag_result']['status'] == 'success':
+            ecr_display = 'ECR tag updated'
+        else:
+            ecr_display = ''
+
+        if not summary['ecs_deployments']:
+            ecs_display = ''
+        elif len(summary['ecs_deployments']) == 1:
+            ecs_display = '1 service deployed'
+        else:
+            ecs_display = '%d services deployed' % len(summary['ecs_deployments'])
+
+        if not ecr_display and not ecs_display:
+            rows.append([image_id, '-'])
+        elif not ecr_display:
+            rows.append([image_id, ecs_display])
+        else:
+            rows.append([image_id, ', '.join([ecr_display, ecs_display])])
+
+    click.echo(tabulate(rows, headers=headers))
 
     click.echo("")
     click.echo(click.style(f"Deployed release {release['release_id']} to {env_id}, ({env_name})", fg="bright_green"))

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -343,17 +343,20 @@ class Project:
 
             return ecs_services_deployed[service['response']['serviceArn']]
 
-        for image_id, image_name in release['images'].items():
+        for image_id, image_name in sorted(release['images'].items()):
             tag_result = self._tag_ecr_image(
                 environment_id=environment_id,
                 image_id=image_id,
                 image_name=image_name
             )
 
-            ecs_deployments = [
-                _ecs_deploy(service)
-                for service in matched_services.get(image_id, [])
-            ]
+            if tag_result['status'] == 'noop':
+                ecs_deployments = []
+            else:
+                ecs_deployments = [
+                    _ecs_deploy(service)
+                    for service in matched_services.get(image_id, [])
+                ]
 
             deployment_details[image_id] = {
                 'tag_result': tag_result,

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -350,18 +350,10 @@ class Project:
                 image_name=image_name
             )
 
-            ecs_deployments = []
-            if image_id in matched_services:
-
-                deployments = [_ecs_deploy(service) for service in matched_services.get(image_id)]
-
-                for deployment in deployments:
-                    service_arn = deployment['service_arn']
-                    deployment_id = deployment['deployment_id']
-                    ecs_deployments.append({
-                        'service_arn': service_arn,
-                        'deployment_id': deployment_id
-                    })
+            ecs_deployments = [
+                _ecs_deploy(service)
+                for service in matched_services.get(image_id, [])
+            ]
 
             deployment_details[image_id] = {
                 'tag_result': tag_result,


### PR DESCRIPTION
This patch makes two changes:

* Drastically simplify the output from a successful 'deploy' command. At most I want to know stuff is happening; the exact deployment IDs are massively overkill.
* The ECR tagging function already returns a `status: noop` if the image tags aren't changing. If we can catch and notice that, we can skip churning services that won't be changed with a deployment.

Previously:

![Screenshot 2020-09-17 at 13 33 54](https://user-images.githubusercontent.com/301220/93470860-73611780-f8ea-11ea-83e6-27131ab583f1.png)

Now:

![Screenshot 2020-09-17 at 13 33 11](https://user-images.githubusercontent.com/301220/93470869-765c0800-f8ea-11ea-9b44-3824b18ec97d.png)