### PR TITLE
Add ssh for git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer = "Wellcome Collection <dev@wellcomecollection.org>"
 LABEL description = "A Docker image for deploying our Docker images to AWS"
 
 RUN apk update && \
-    apk add docker git
+    apk add docker git openssh
 
 RUN pip install awscli
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Adds openssh to the Dockerfile (required by git in some environments).


### PR DESCRIPTION
This can cause failures where git requires ssh to function.

See https://buildkite.com/wellcomecollection/front-end-wellcomecollection-dot-org/builds/41#072f67e8-720a-4582-a3bc-3647d0e55395/128-148