### PR TITLE
Tag ECS services with release ID

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+When a deployment occurs, ECS services will be tagged with the release id at key "deployment:label"/
+
+This provides a way to identify the release a service should be trying to enact (and by looking up that relationship identify which image is associated with which task). 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: minor
 
-When a deployment occurs, ECS services will be tagged with the release id at key "deployment:label"/
+When a deployment occurs, ECS services will be tagged with the release id at key "deployment:label".
 
 This provides a way to identify the release a service should be trying to enact (and by looking up that relationship identify which image is associated with which task). 

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -47,11 +47,19 @@ class Ecs:
         for page in paginator.paginate(cluster=cluster_arn):
             yield from page["serviceArns"]
 
-    def redeploy_service(self, cluster_arn, service_arn):
+    def redeploy_service(self, cluster_arn, service_arn, deployment_label):
         response = self.ecs.update_service(
             cluster=cluster_arn,
             service=service_arn,
             forceNewDeployment=True
+        )
+
+        self.ecs.tag_resource(
+            resourceArn=service_arn,
+            tags=[{
+                'key': 'deployment:label',
+                'value': deployment_label
+            }]
         )
 
         return {


### PR DESCRIPTION
When a deployment occurs, ECS services will be tagged with the release id at key "deployment:label".

This provides a way to identify the release a service should be trying to enact (and from looking up that relationship identify which image is associated with which task). 

This is moving towards identifying the status of a release.

*Note*: For this to work without causing churn on terraform apply, the release from this PR should be incorporated: https://github.com/wellcomecollection/terraform-aws-ecs-service/pull/27