### PR TITLE
Add update command

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Adds a new update command, allowing specific services to be updated from a previous release.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -262,12 +262,7 @@ def deploy(ctx, release_id, environment_id, description):
     )
 
 
-def _prepare(project, from_label, description):
-    release = project.prepare(
-        from_label=from_label,
-        description=description
-    )
-
+def _display_release(release, from_label):
     prev_release = release["previous_release"]
     new_release = release["new_release"]
 
@@ -313,6 +308,20 @@ def _prepare(project, from_label, description):
     return new_release['release_id']
 
 
+def _prepare(project, from_label, description):
+    release = project.prepare(
+        from_label=from_label,
+        description=description
+    )
+
+    _display_release(
+        release=release,
+        from_label=from_label
+    )
+
+    return release["new_release"]
+
+
 @cli.command()
 @click.option('--from-label', prompt="Label to base release upon",
               help="The existing label upon which this release will be based",
@@ -327,6 +336,41 @@ def prepare(ctx, from_label, description):
         project=project,
         from_label=from_label,
         description=description
+    )
+
+
+def _update(project, release_id, service_ids, from_label):
+    release = project.update(
+        release_id=release_id,
+        service_ids=service_ids,
+        from_label=from_label
+    )
+
+    _display_release(
+        release=release,
+        from_label=from_label
+    )
+
+    return release["new_release"]
+
+
+@cli.command()
+@click.option('--release-id', prompt="Release ID to deploy", default="latest", show_default=True,
+              help="The release ID from which to create a new release")
+@click.option('--service-ids', prompt="Comma separated list of Service IDs",
+              help="The services which will be updated")
+@click.option('--from-label', prompt="Label to base release upon",
+              help="The existing label from which to update specified services",
+              default="latest", show_default=True)
+@click.pass_context
+def update(ctx, release_id, service_ids, from_label):
+    project = ctx.obj['project']
+
+    _update(
+        project=project,
+        release_id=release_id,
+        service_ids=service_ids.split(","),
+        from_label=from_label,
     )
 
 

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -276,9 +276,6 @@ class Project:
         return release_images
 
     def _prepare_release(self, description, release_images):
-        if not release_images:
-            raise RuntimeError(f"No images found for {self.id}/{from_label}")
-
         previous_release = self.releases_store.get_latest_release()
 
         new_release = self._create_release(
@@ -292,6 +289,9 @@ class Project:
 
     def prepare(self, from_label, description):
         release_images = self.get_images(from_label)
+        
+        if not release_images:
+            raise RuntimeError(f"No images found for {self.id}/{from_label}")
 
         return self._prepare_release(
             description=description,

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -289,7 +289,7 @@ class Project:
 
     def prepare(self, from_label, description):
         release_images = self.get_images(from_label)
-        
+
         if not release_images:
             raise RuntimeError(f"No images found for {self.id}/{from_label}")
 


### PR DESCRIPTION
Adds an `update` command allowing you to specify a previous release, a comma separated list of services to update and a label to update them from, e.g.

```
weco-deploy --project-id catalogue_api update \
  --service-ids snapshot_generator \
  --release-id latest \
  --from-label ref.e8f3855ac208dd610bdc2bd964a683db65ee4c42
```

<img width="1040" alt="Screenshot 2020-09-29 at 11 04 57" src="https://user-images.githubusercontent.com/953792/94545187-1e0afb80-0244-11eb-8de1-c791ed52e6c4.png">
