### PR TITLE
Always return a consistent # of deployments, sorted by date

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+When running the ``show-deployments`` command, you always get a consistent number of deployments (the most recent 10) and deployments are sorted by deployment date.

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -168,10 +168,14 @@ class Project:
         return environments[environment_id]
 
     def get_deployments(self, release_id=None):
-        if release_id:
-            return [self.releases_store.get_release(release_id)]
+        if release_id is not None:
+            release = self.releases_store.get_release(release_id)
+
+            for d in release["deployments"]:
+                d["release_id"] = release_id
+                yield d
         else:
-            return self.releases_store.get_recent_deployments()
+            yield from self.releases_store.get_recent_deployments()
 
     def get_release(self, release_id):
         if release_id == "latest":


### PR DESCRIPTION
This arose out of a frustration with the existing output – deployments are sorted by release ID, rather than deployment date.

```
release ID                            environment ID    deployed date                request by                            description
------------------------------------  ----------------  ---------------------------  ------------------------------------  -------------------------------------------------------------
28bcd0c2-2405-4c5e-ab7c-a7fe9c70af05  staging           yesterday @ 13:46            i-04ae559b22c73c7d1                   https://buildkite.com/wellcomecollection/catalogue/builds/777
5051d7a9-718a-4a97-8e17-c06179d26e5c  staging           yesterday @ 13:43            i-02b883f8dd2b80704                   https://buildkite.com/wellcomecollection/catalogue/builds/775
acc7aa19-ee43-4283-9966-c3d939170e3e  staging           yesterday @ 12:30            i-05192edef4baba16a                   https://buildkite.com/wellcomecollection/catalogue/builds/771
5e910e3d-48f4-49cf-811b-067308f91b31  staging           Mon  5 October 2020 @ 09:14  chana@Wellcomecloud.onmicrosoft.com   No description provided
5e910e3d-48f4-49cf-811b-067308f91b31  prod              Mon  5 October 2020 @ 09:24  chana@Wellcomecloud.onmicrosoft.com   first deploy in catalogue account
5e910e3d-48f4-49cf-811b-067308f91b31  prod              Tue  6 October 2020 @ 09:00  KennyR@Wellcomecloud.onmicrosoft.com  No description provided
5e910e3d-48f4-49cf-811b-067308f91b31  prod              yesterday @ 12:25            KennyR@Wellcomecloud.onmicrosoft.com  No description provided
d2042f69-b164-4125-9266-8ae3a5165ae9  staging           yesterday @ 12:10            KennyR@Wellcomecloud.onmicrosoft.com  No description provided
d2042f69-b164-4125-9266-8ae3a5165ae9  staging           yesterday @ 12:11            KennyR@Wellcomecloud.onmicrosoft.com  No description provided
d2042f69-b164-4125-9266-8ae3a5165ae9  staging           yesterday @ 12:13            KennyR@Wellcomecloud.onmicrosoft.com  No description provided
0b3ad1a6-38ee-4b00-9755-3c99aedc9182  staging           yesterday @ 11:44            i-0c06be5472b42cf64                   https://buildkite.com/wellcomecollection/catalogue/builds/770
411b9a02-d9dd-457c-81a5-241ba6a274de  staging           Tue  6 October 2020 @ 16:07  i-0a9c6ebcd7ec3beb8                   https://buildkite.com/wellcomecollection/catalogue/builds/740
56055130-1393-4108-9191-c542279b81b9  staging           Tue  6 October 2020 @ 12:27  i-075c5ce626a85c381                   https://buildkite.com/wellcomecollection/catalogue/builds/729
67df3f75-6b9c-4200-82ec-9ac93d201733  staging           Tue  6 October 2020 @ 09:42  i-0851e5579d4050cf4                   https://buildkite.com/wellcomecollection/catalogue/builds/725
fb15d916-225a-4773-b7c7-588a6c22c22a  staging           Tue  6 October 2020 @ 09:29  i-06daf83aa703f180c                   https://buildkite.com/wellcomecollection/catalogue/builds/724
```

This makes it hard to see if there was a deployment at a given time – they don't form a consistent timeline. I tugged on the thread to get sorted output, and a couple of things fell out.

* It was possible for the deployment timeline to be incomplete – that is, there could be deployments which occurred *after* a listed deployment but which weren't included in the table. See the comment for an example. That's now fixed.
* The number of results would vary based on the releases. Also fixed.
* The results are now sorted by deploy date, rather than release ID.
* Emphasise descriptions that are provided; de-emphasise cases where somebody didn't provide a description.

Example of the new output:

```
release ID                            environment ID    deployed date                request by                            description
------------------------------------  ----------------  ---------------------------  ------------------------------------  -------------------------------------------------------------
28bcd0c2-2405-4c5e-ab7c-a7fe9c70af05  staging           yesterday @ 13:46            i-04ae559b22c73c7d1                   https://buildkite.com/wellcomecollection/catalogue/builds/777
5051d7a9-718a-4a97-8e17-c06179d26e5c  staging           yesterday @ 13:43            i-02b883f8dd2b80704                   https://buildkite.com/wellcomecollection/catalogue/builds/775
acc7aa19-ee43-4283-9966-c3d939170e3e  staging           yesterday @ 12:30            i-05192edef4baba16a                   https://buildkite.com/wellcomecollection/catalogue/builds/771
5e910e3d-48f4-49cf-811b-067308f91b31  prod              yesterday @ 12:25            KennyR@Wellcomecloud.onmicrosoft.com  -
d2042f69-b164-4125-9266-8ae3a5165ae9  staging           yesterday @ 12:13            KennyR@Wellcomecloud.onmicrosoft.com  -
d2042f69-b164-4125-9266-8ae3a5165ae9  staging           yesterday @ 12:11            KennyR@Wellcomecloud.onmicrosoft.com  -
d2042f69-b164-4125-9266-8ae3a5165ae9  staging           yesterday @ 12:10            KennyR@Wellcomecloud.onmicrosoft.com  -
0b3ad1a6-38ee-4b00-9755-3c99aedc9182  staging           yesterday @ 11:44            i-0c06be5472b42cf64                   https://buildkite.com/wellcomecollection/catalogue/builds/770
411b9a02-d9dd-457c-81a5-241ba6a274de  staging           Tue  6 October 2020 @ 16:07  i-0a9c6ebcd7ec3beb8                   https://buildkite.com/wellcomecollection/catalogue/builds/740
56055130-1393-4108-9191-c542279b81b9  staging           Tue  6 October 2020 @ 12:27  i-075c5ce626a85c381                   https://buildkite.com/wellcomecollection/catalogue/builds/729
```