### PR TITLE
Fix a TypeError from --project-id with bad project ID

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix an unexpected error that would be thrown if you passed `--project-id` with an unrecognised project ID.

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -34,20 +34,13 @@ class Projects:
     def list(self):
         return list(self.projects.keys())
 
-    def load(self, project_id, region_name=None, role_arn=None, account_id=None, namespace=None):
-        config = self.projects.get(project_id)
+    def load(self, project_id, **kwargs):
+        try:
+            config = self.projects[project_id]
+        except KeyError:
+            raise RuntimeError(f"No matching project {project_id} in {self.projects}")
 
-        if not config:
-            raise RuntimeError(f"No matching project {project_id} in {self.projects()}")
-
-        return Project(
-            project_id=project_id,
-            config=config,
-            region_name=region_name,
-            role_arn=role_arn,
-            account_id=account_id,
-            namespace=namespace
-        )
+        return Project(project_id=project_id, config=config, **kwargs)
 
 
 class Project:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,15 @@
+import pytest
+
+from deploy.project import Projects
+
+
+def test_loading_non_existent_project_is_runtimeerror(tmpdir):
+    project_filepath = str(tmpdir / ".wellcome_project")
+
+    with open(project_filepath, "w") as outfile:
+        outfile.write("test_project: true")
+
+    project = Projects(project_filepath)
+
+    with pytest.raises(RuntimeError, match="No matching project doesnotexist"):
+        project.load(project_id="doesnotexist")


### PR DESCRIPTION
It would throw the following exception:

    raise RuntimeError(f"No matching project {project_id} in {self.projects()}")
    TypeError: 'dict' object is not callable

It should be `self.projects`.