### PR TITLE
Allow seeing more deployments

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+Allow getting more than 10 deployments with the ``show-deployments`` command.
+
+Get more deployments by passing ``--limit=LIMIT``, e.g. ``--limit=25``.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -401,8 +401,9 @@ def show_release(ctx, release_id):
 
 @cli.command()
 @click.argument('release_id', required=False)
+@click.option('--limit', required=False, default=10)
 @click.pass_context
-def show_deployments(ctx, release_id):
+def show_deployments(ctx, release_id, limit):
     project = ctx.obj['project']
 
     rows = []
@@ -415,7 +416,7 @@ def show_deployments(ctx, release_id):
         "description"
     ]
 
-    for deployment in project.get_deployments(release_id=release_id):
+    for deployment in project.get_deployments(release_id=release_id, limit=limit):
         rows.append(
             [
                 deployment["release_id"],

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -160,15 +160,19 @@ class Project:
 
         return environments[environment_id]
 
-    def get_deployments(self, release_id=None):
+    def get_deployments(self, release_id, limit):
         if release_id is not None:
             release = self.releases_store.get_release(release_id)
 
             for d in release["deployments"]:
                 d["release_id"] = release_id
-                yield d
+
+            deployments = release_id["deployments"]
         else:
-            yield from self.releases_store.get_recent_deployments()
+            deployments = self.releases_store.get_recent_deployments(limit=limit)
+
+        deployments = sorted(deployments, key=lambda d: d["date_created"], reverse=True)
+        return deployments[:limit]
 
     def get_release(self, release_id):
         if release_id == "latest":


### PR DESCRIPTION
Follows #46.

There's no good way to say _"show me the most recent N deployments in an environment"_, which is a pain if one environment is way more common than the other:

```
release ID                            environment ID    deployed date                request by                            description
------------------------------------  ----------------  ---------------------------  ------------------------------------  -------------------------------------------------------------
28bcd0c2-2405-4c5e-ab7c-a7fe9c70af05  staging           yesterday @ 13:46            i-04ae559b22c73c7d1                   https://buildkite.com/wellcomecollection/catalogue/builds/777
5051d7a9-718a-4a97-8e17-c06179d26e5c  staging           yesterday @ 13:43            i-02b883f8dd2b80704                   https://buildkite.com/wellcomecollection/catalogue/builds/775
acc7aa19-ee43-4283-9966-c3d939170e3e  staging           yesterday @ 12:30            i-05192edef4baba16a                   https://buildkite.com/wellcomecollection/catalogue/builds/771
5e910e3d-48f4-49cf-811b-067308f91b31  prod              yesterday @ 12:25            KennyR@Wellcomecloud.onmicrosoft.com  -
d2042f69-b164-4125-9266-8ae3a5165ae9  staging           yesterday @ 12:13            KennyR@Wellcomecloud.onmicrosoft.com  -
d2042f69-b164-4125-9266-8ae3a5165ae9  staging           yesterday @ 12:11            KennyR@Wellcomecloud.onmicrosoft.com  -
d2042f69-b164-4125-9266-8ae3a5165ae9  staging           yesterday @ 12:10            KennyR@Wellcomecloud.onmicrosoft.com  -
0b3ad1a6-38ee-4b00-9755-3c99aedc9182  staging           yesterday @ 11:44            i-0c06be5472b42cf64                   https://buildkite.com/wellcomecollection/catalogue/builds/770
411b9a02-d9dd-457c-81a5-241ba6a274de  staging           Tue  6 October 2020 @ 16:07  i-0a9c6ebcd7ec3beb8                   https://buildkite.com/wellcomecollection/catalogue/builds/740
56055130-1393-4108-9191-c542279b81b9  staging           Tue  6 October 2020 @ 12:27  i-075c5ce626a85c381                   https://buildkite.com/wellcomecollection/catalogue/builds/729
```

This is a stopgap that lets you increase the # of deployments until you see what you want.