### PR TITLE
More verbose deploy waiting

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: minor
 
-Makes waiting for a deployment more verbose byt displaying time waited, along with wait time expectation, and totals after deployment.
+Makes waiting for a deployment more verbose by displaying time waited, along with wait time expectation, and totals after deployment.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Makes waiting for a deployment more verbose byt displaying time waited, along with wait time expectation, and totals after deployment.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -275,12 +275,12 @@ def _confirm_deploy(project, release, environment_id, wait_for_seconds, interval
 
     def _is_release_deployed():
         is_release_deployed = project.is_release_deployed(release, environment_id)
-        waited_for_seconds = time.perf_counter() - start_timer
+        waited_for_seconds = int(time.perf_counter() - start_timer)
 
         if not is_release_deployed and waited_for_seconds < wait_for_seconds:
             click.echo(
                 click.style(
-                    f"Deployment of {release_id} to {environment_id} is not complete. Waiting {interval} seconds",
+                    f"Trying again in {interval}s, (waited {wait_for_seconds}s).",
                     fg="yellow"))
             time.sleep(interval)
             _is_release_deployed()
@@ -289,19 +289,27 @@ def _confirm_deploy(project, release, environment_id, wait_for_seconds, interval
             return False
 
         if is_release_deployed:
-            return True
+            return {
+                'waited_for_seconds': waited_for_seconds
+            }
 
     click.echo("")
     click.echo(click.style(f"Checking deployment of {release_id} to {environment_id}", fg="yellow"))
+    click.echo(click.style(f"Allowing {wait_for_seconds}s for deployment.", fg="yellow"))
 
-    confirmed = _is_release_deployed()
-    if confirmed:
+    confirmation = _is_release_deployed()
+
+    if confirmation:
+        total_wait_time = confirmation['waited_for_seconds']
+
         click.echo("")
         click.echo(click.style(f"Deployment of {release_id} to {environment_id} successful", fg="bright_green"))
+        click.echo(click.style(f"Deployment took {total_wait_time}s", fg="bright_green"))
         sys.exit(0)
     else:
         click.echo("")
         click.echo(click.style(f"Deployment of {release_id} to {environment_id} failed", fg="red"))
+        click.echo(click.style(f"Deployment time exceeded {wait_for_seconds}s", fg="red"))
         sys.exit(1)
 
 


### PR DESCRIPTION
Makes waiting for a deployment more verbose by displaying time waited, along with wait time expectation, and totals after deployment.

<img width="795" alt="Screenshot 2020-10-22 at 13 59 53" src="https://user-images.githubusercontent.com/953792/96875247-ea03ae80-146e-11eb-937b-4b2baba7097b.png">
