### PR TITLE
Speed up the table of discovered services in the deploy command

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Speed up loading the table "ECS services discovered" when running the ``deploy`` command.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -167,7 +167,7 @@ def _deploy(project, release, environment_id, description, confirm=True):
     click.echo(click.style(f"Requested by: {release['requested_by']}", fg="yellow"))
     click.echo(click.style(f"Date created: {release['date_created']}", fg="yellow"))
 
-    ecs_services = project.get_ecs_services(
+    ecs_service_arns = project.get_ecs_service_arns(
         release=release,
         environment_id=environment_id
     )
@@ -176,12 +176,12 @@ def _deploy(project, release, environment_id, description, confirm=True):
 
     headers = ["image ID", "services"]
 
-    def _get_service_name(service):
-        return click.style(service['response']["serviceArn"].split("/")[-1], fg="green")
-
-    for image_id, services in sorted(ecs_services.items()):
-        service_names = [_get_service_name(service) for service in services]
-        rows.append([image_id, "\n".join(sorted(service_names))])
+    for image_id, service_arns in sorted(ecs_service_arns.items()):
+        names = [
+            click.style(arn.split("/")[-1], fg="green")
+            for arn in service_arns
+        ]
+        rows.append([image_id, "\n".join(sorted(names))])
 
     click.echo("")
     click.echo(click.style("ECS services discovered:\n", fg="yellow", underline=True))

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 import functools
 from urllib.parse import urlparse


### PR DESCRIPTION
By caching the result of Project._ecs(), we don't create a new instance of Ecs each time.  This in turn means we don't have to re-fetch all the service data from the ECS API.

Also add some new methods to be more explicit about what's being passed around.