### PR TITLE
Make weco-deploy slightly faster when looking up Git commits

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Make weco-deploy slightly faster when looking up Git commits.

--- a/src/deploy/git.py
+++ b/src/deploy/git.py
@@ -5,15 +5,22 @@ from .commands import cmd
 
 
 @functools.lru_cache()
-def log(commit_id):
+def log(commit_id, run_fetch=True):
     """
     Returns a one-line log for a given commit ID.
     """
     try:
-        cmd("git", "fetch", "origin")
-
         # %s = subject, the first line of the commit
         # See https://git-scm.com/docs/pretty-formats
-        return cmd("git", "show", "-s", "--format=%s", commit_id)
+        show_cmd = ["git", "show", "-s", "--format=%s", commit_id]
+        return subprocess.check_output(show_cmd).decode("utf8").strip()
+
     except subprocess.CalledProcessError:
-        return ""
+        # If we couldn't find the commit, run a 'git fetch' and see if it's
+        # available in the remote state.  If we still can't find it after that,
+        # give up and return an empty string.
+        if run_fetch:
+            cmd("git", "fetch", "origin")
+            log(commit_id, run_fetch=False)
+        else:
+            return ""

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,9 @@
+from deploy.git import log
+
+
+def test_gets_commit_log():
+    assert log("125d42f") == "Bump version to 5.4.3 and update changelog"
+
+
+def test_returns_empty_string_for_missing_commit():
+    assert log("doesnotexist", run_fetch=False) == ""


### PR DESCRIPTION
In particular, if the commit we're looking at is already in our local repo, we don't need to fetch from the remote state to find it.