### PR TITLE
Handle the case when asked to describe an image that does not exist gracefully.

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Handle the case asked to describe an image that does not exist gracefully.
+
+This fixes an issue with the update command that would fail when the label requested was not available for all services in a project, even though a subset were being updated.

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -358,7 +358,8 @@ class Project:
                 account_id=image.get('account_id')
             )
 
-            release_images[image_details['image_id']] = image_details['ref']
+            if image_details:
+                release_images[image_details['image_id']] = image_details['ref']
 
         return release_images
 


### PR DESCRIPTION
This fixes an issue with the update command that would fail when the label requested was not available for all services in a project, even though a subset were being updated.