### PR TITLE
Naive filter on environment for show_deployments

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Adds an --environment-id filter to show-deployments command. This allows a better view on deployments when looking for example for the last good deploy.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,3 +1,3 @@
 RELEASE_TYPE: minor
 
-Adds an --environment-id filter to show-deployments command. This allows a better view on deployments when looking for example for the last good deploy.
+Adds an --environment-id filter to show-deployments command. This allows a better view on deployments when looking for example for the last good prod deploy.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -473,9 +473,10 @@ def show_release(ctx, release_id):
 
 @cli.command()
 @click.argument('release_id', required=False)
+@click.option('--environment-id', required=False)
 @click.option('--limit', required=False, default=10)
 @click.pass_context
-def show_deployments(ctx, release_id, limit):
+def show_deployments(ctx, release_id, environment_id, limit):
     project = ctx.obj['project']
 
     rows = []
@@ -488,7 +489,11 @@ def show_deployments(ctx, release_id, limit):
         "description"
     ]
 
-    for deployment in project.get_deployments(release_id=release_id, limit=limit):
+    for deployment in project.get_deployments(
+            release_id=release_id,
+            environment_id=environment_id,
+            limit=limit
+    ):
         rows.append(
             [
                 deployment["release_id"],

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -164,7 +164,7 @@ class Project:
 
         return environments[environment_id]
 
-    def get_deployments(self, release_id, limit):
+    def get_deployments(self, release_id, limit, environment_id):
         if release_id is not None:
             release = self.releases_store.get_release(release_id)
 
@@ -173,7 +173,10 @@ class Project:
 
             deployments = release_id["deployments"]
         else:
-            deployments = self.releases_store.get_recent_deployments(limit=limit)
+            deployments = self.releases_store.get_recent_deployments(
+                environment_id=environment_id,
+                limit=limit
+            )
 
         deployments = sorted(deployments, key=lambda d: d["date_created"], reverse=True)
         return deployments[:limit]


### PR DESCRIPTION
Adds an `--environment-id` filter to show-deployments command. This allows a better view on deployments when looking for example for the last good deploy.

Note: This filters the already limited list which is not ideal but this at least gives us a slightly better view on deployments.