### PR TITLE
Add a function for finding resources matching a set of tags

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal refactoring.  This should have no user-visible effect.

--- a/src/deploy/tags.py
+++ b/src/deploy/tags.py
@@ -20,3 +20,45 @@ def parse_aws_tags(tags):
         result[aws_tag["key"]] = aws_tag["value"]
 
     return result
+
+
+class MultipleMatchingResourcesError(ValueError):
+    """
+    Raised if there are multiple resources matching a given set of tags.
+    """
+
+
+class NoMatchingResourceError(ValueError):
+    """
+    Raised if there is no resource matching a given set of tags.
+    """
+    pass
+
+
+def find_unique_resource_matching_tags(resources, *, expected_tags):
+    """
+    Given a list of AWS resources, find the unique resource matching a given
+    set of tags.
+
+    The tags should be a Python dictionary, e.g. {"key1": "value1", "key2": "value2"}
+    """
+    if not expected_tags:
+        raise ValueError("Cannot match against an empty set of tags")
+
+    def _is_match(resource):
+        resource_tags = parse_aws_tags(resource.get("tags", []))
+        return all(
+            k in resource_tags and resource_tags[k] == v
+            for k, v in expected_tags.items()
+        )
+
+    matching_resources = [r for r in resources if _is_match(r)]
+
+    if len(matching_resources) == 1:
+        return matching_resources[0]
+    elif not matching_resources:
+        raise NoMatchingResourceError(f"Could not find any resources with tags {expected_tags}")
+    else:
+        raise MultipleMatchingResourcesError(
+            f"Found multiple resources with tags {expected_tags}, expected one: {matching_resources}"
+        )

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,6 +1,11 @@
 import pytest
 
-from deploy.tags import parse_aws_tags
+from deploy.tags import (
+    find_unique_resource_matching_tags,
+    parse_aws_tags,
+    MultipleMatchingResourcesError,
+    NoMatchingResourceError,
+)
 
 
 @pytest.mark.parametrize(
@@ -18,3 +23,113 @@ from deploy.tags import parse_aws_tags
 )
 def test_parse_aws_tags(aws_tags, expected_tags):
     assert parse_aws_tags(aws_tags) == expected_tags
+
+
+class TestFindUniqueResourceMatchingTags:
+    def test_finds_unique_matching_resource(self):
+        """
+        find_unique_resource_matching_tags finds a resource with a single matching tag.
+        """
+        resources = [
+            {"name": "bag-unpacker", "tags": [{"key": "name", "value": "unpacker"}]},
+            {"name": "bag-verifier", "tags": [{"key": "name", "value": "verifier"}]},
+            {"name": "app-untagged"},
+        ]
+
+        match = find_unique_resource_matching_tags(
+            resources, expected_tags={"name": "unpacker"}
+        )
+
+        assert match == resources[0]
+
+    def test_matching_on_multiple_tags(self):
+        """
+        find_unique_resource_matching_tags can match on multiple tags, including
+        a subset of the available tags.
+        """
+        resources = [
+            {
+                "name": "app-prod",
+                "tags": [
+                    {"key": "name", "value": "app"},
+                    {"key": "env", "value": "prod"},
+                    {"key": "ref", "value": "git.123"},
+                ],
+            },
+            {
+                "name": "app-stage",
+                "tags": [
+                    {"key": "name", "value": "app"},
+                    {"key": "env", "value": "stage"},
+                    {"key": "ref", "value": "git.123"},
+                ],
+            },
+            {"name": "app-untagged"},
+        ]
+
+        match = find_unique_resource_matching_tags(
+            resources, expected_tags={"name": "app", "env": "prod"}
+        )
+
+        assert match == resources[0]
+
+    def test_empty_tags_is_error(self):
+        """
+        Trying to match on an empty set of tags is an error.
+        """
+        resources = [{"name": "app", "tags": [{"key": "env", "value": "prod"}]}]
+
+        with pytest.raises(
+            ValueError, match="Cannot match against an empty set of tags"
+        ):
+            find_unique_resource_matching_tags(resources, expected_tags={})
+
+    def test_multiple_matching_resources_is_error(self):
+        """
+        If there are multiple resources with the expected tags, an error is thrown.
+        """
+        resources = [
+            {
+                "name": "app-prod",
+                "tags": [
+                    {"key": "name", "value": "app"},
+                    {"key": "env", "value": "prod"},
+                ],
+            },
+            {
+                "name": "app-stage",
+                "tags": [
+                    {"key": "name", "value": "app"},
+                    {"key": "env", "value": "stage"},
+                ],
+            },
+        ]
+
+        with pytest.raises(MultipleMatchingResourcesError):
+            find_unique_resource_matching_tags(resources, expected_tags={"name": "app"})
+
+    def test_no_matching_resources_is_error(self):
+        """
+        If there are no resources with the expected tags, an error is thrown.
+        """
+        resources = [
+            {
+                "name": "app-prod",
+                "tags": [
+                    {"key": "name", "value": "app"},
+                    {"key": "env", "value": "prod"},
+                ],
+            },
+            {
+                "name": "app-stage",
+                "tags": [
+                    {"key": "name", "value": "app"},
+                    {"key": "env", "value": "stage"},
+                ],
+            },
+        ]
+
+        with pytest.raises(NoMatchingResourceError):
+            find_unique_resource_matching_tags(
+                resources, expected_tags={"name": "worker"}
+            )


### PR DESCRIPTION
Spotted while debugging some ECS stuff.

The function `find_matching_service()` isn't doing anything ECS specific, just looking through a list of AWS resources to find the unique resource matching a set of tags. We can pull that out into a standalone function and test it separately.

Coverage: 28% ~> 30%