### PR TITLE
Simplify the internal logic for dealing with ECR

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal refactoring.  This should have no user-visible effect.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -18,16 +18,6 @@ DEFAULT_PROJECT_FILEPATH = ".wellcome_project"
 LOGGING_ROOT = os.path.join(os.environ["HOME"], ".local", "share", "weco-deploy")
 
 
-def _format_ecr_uri(uri):
-    image_name = uri.split("/")[2]
-    image_label, image_tag = image_name.split(":")
-
-    return {
-        'label': image_label,
-        'tag': image_tag
-    }
-
-
 @click.group()
 @click.option('--project-file', '-f', default=DEFAULT_PROJECT_FILEPATH)
 @click.option('--verbose', '-v', is_flag=True, help="Print verbose messages.")
@@ -523,9 +513,14 @@ def show_images(ctx, label):
         "tag",
     ]
 
-    for image_id, ecr_uri in images.items():
-        ecr_uri = _format_ecr_uri(ecr_uri)
-        rows.append([image_id, ecr_uri["label"], ecr_uri["tag"]])
+    for image_id, ref_tags in images.items():
+        if ref_tags:
+            # It's possible to get multiple ref tags if the same image is published
+            # at different Git commits, but there are no code changes for this image
+            # between the two commits.  If so, choose one arbitrarily.
+            rows.append([image_id, label, ref_tags.pop()])
+        else:
+            rows.append([image_id, "-", "-"])
 
     print(tabulate(rows, headers=headers))
 

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -204,7 +204,7 @@ def get_ref_tags_for_repositories(*, image_repositories, tag):
                 tag=tag,
                 account_id=account_id
             )
-        except NoSuchImageError as err:
+        except NoSuchImageError:
             result[repo_id] = set()
         else:
             result[repo_id] = ref_uri

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -22,12 +22,11 @@ class Ecr:
     def __init__(self, account_id, region_name, role_arn):
         self.account_id = account_id
         self.region_name = region_name
-        self.session = Iam.get_session(
-            session_name="ReleaseToolEcr",
-            role_arn=role_arn,
-            region_name=region_name
+        self.ecr = create_client(
+            account_id=account_id,
+            region_name=region_name,
+            role_arn=role_arn
         )
-        self.ecr = self.session.client('ecr')
 
         self.ecr_base_uri = (
             f"{self.account_id}.dkr.ecr.{self.region_name}.amazonaws.com"

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -163,22 +163,21 @@ def describe_image(ecr_client, ecr_base_uri, namespace, image_id, tag, account_i
             repositoryName=repository_name,
             imageIds=[{"imageTag": tag}],
         )
-
-        image = EcrImage(
-            ecr_base_uri=ecr_base_uri,
-            repository_name=repository_name,
-            tag=tag,
-            describe_images_resp=result,
-        )
-
-        return {
-            "image_id": image_id,
-            "ref": image.ref_uri(),
-        }
-
     except ClientError as e:
         # Matching tag & digest already exists (nothing to do)
         if not e.response["Error"]["Code"] == "ImageNotFoundException":  # pragma: no cover
             raise e
         else:
             return None
+
+    image = EcrImage(
+        ecr_base_uri=ecr_base_uri,
+        repository_name=repository_name,
+        tag=tag,
+        describe_images_resp=result,
+    )
+
+    return {
+        "image_id": image_id,
+        "ref": image.ref_uri(),
+    }

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -53,16 +53,6 @@ class Ecr:
 
         return remote_image_name, remote_image_tag, local_image_tag
 
-    def describe_image(self, namespace, image_id, tag, account_id=None):
-        return describe_image(
-            ecr_client=self.ecr,
-            ecr_base_uri=self.ecr_base_uri,
-            namespace=namespace,
-            image_id=image_id,
-            tag=tag,
-            account_id=account_id or self.account_id
-        )
-
     def tag_image(self, namespace, image_id, tag, new_tag):
         repository_name = Ecr._get_repository_name(namespace, image_id)
 

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -370,7 +370,7 @@ class Project:
                 "repository_name": f"{namespace}/{repo['id']}"
             }
 
-        return ecr.get_ref_uris_for_repositories(
+        return ecr.get_ref_tags_for_repositories(
             image_repositories=image_repositories,
             tag=from_label
         )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 coverage
+moto
 pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+import os
+
+import boto3
+import moto
+import pytest
+
+
+@pytest.fixture(scope="session")
+def region_name():
+    return "eu-west-1"
+
+
+@pytest.fixture(scope="session")
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+
+
+@pytest.fixture(scope="session")
+def ecr_client(aws_credentials, region_name):
+    with moto.mock_ecr():
+        yield boto3.client("ecr", region_name=region_name)

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -1,124 +1,11 @@
 import hashlib
 import json
 from random import random
-import secrets
 
 from botocore.exceptions import ClientError
 import pytest
 
 from deploy import ecr
-from deploy.ecr import EcrImage
-from deploy.exceptions import EcrError
-
-
-@pytest.fixture
-def repository_name():
-    return f"repo-{secrets.token_hex()}"
-
-
-@pytest.fixture
-def tag():
-    return f"tag-{secrets.token_hex()}"
-
-
-@pytest.fixture
-def ecr_base_uri():
-    return "1234567890.ecr.example.aws.com"
-
-
-def test_no_image_details_is_error(ecr_base_uri, repository_name, tag):
-    """
-    If the response from the ECR DescribeImage API doesn't contain an "imageDetails"
-    field, we throw an error.
-    """
-    with pytest.raises(
-        EcrError, match=f"No matching images found for {repository_name}:{tag}!"
-    ):
-        EcrImage(
-            ecr_base_uri=ecr_base_uri,
-            repository_name=repository_name,
-            tag=tag,
-            describe_images_resp={"imageDetails": []},
-        )
-
-
-def test_multiple_matching_images_is_error(ecr_base_uri, repository_name, tag):
-    """
-    If the response from the ECR DescribeImage API contains multiple images in
-    the "imageDetails" field, we throw an error.
-    """
-    repository_name = "example"
-    tag = "123"
-
-    with pytest.raises(
-        EcrError, match=f"Multiple matching images found for {repository_name}:{tag}!"
-    ):
-        EcrImage(
-            ecr_base_uri=ecr_base_uri,
-            repository_name=repository_name,
-            tag=tag,
-            describe_images_resp={
-                "imageDetails": [{"name": "image1"}, {"name": "image2"}]
-            },
-        )
-
-
-def test_no_ref_tag_is_error(ecr_base_uri, repository_name, tag):
-    image = EcrImage(
-        ecr_base_uri=ecr_base_uri,
-        repository_name=repository_name,
-        tag=tag,
-        describe_images_resp={"imageDetails": [{"name": "my_image", "imageTags": []}]},
-    )
-
-    with pytest.raises(
-        EcrError, match=f"No matching ref tags found for {repository_name}:{tag}!"
-    ):
-        image.ref_uri()
-
-
-def test_gets_ref_uri():
-    image = EcrImage(
-        ecr_base_uri="1234567890.ecr.example.aws.com",
-        repository_name="example_worker",
-        tag="123abc",
-        describe_images_resp={
-            "imageDetails": [{"name": "my_image", "imageTags": ["ref.abcdef1"]}]
-        },
-    )
-
-    assert (
-        image.ref_uri() == "1234567890.ecr.example.aws.com/example_worker:ref.abcdef1"
-    )
-
-
-def test_chooses_ref_uri_arbitrarily():
-    image = EcrImage(
-        ecr_base_uri="1234567890.ecr.example.aws.com",
-        repository_name="example_worker",
-        tag="123abc",
-        describe_images_resp={
-            "imageDetails": [
-                {"name": "my_image", "imageTags": ["ref.abcdef1", "ref.1fedcba"]}
-            ]
-        },
-    )
-
-    assert image.ref_uri() in {
-        "1234567890.ecr.example.aws.com/example_worker:ref.abcdef1",
-        "1234567890.ecr.example.aws.com/example_worker:ref.1fedcba",
-    }
-
-
-def test_repository_name(ecr_base_uri, repository_name, tag):
-    image = EcrImage(
-        ecr_base_uri=ecr_base_uri,
-        repository_name=repository_name,
-        tag=tag,
-        describe_images_resp={"imageDetails": [{"repositoryName": repository_name}]},
-    )
-
-    assert image.repository_name == repository_name
 
 
 # Taken from https://github.com/rubelw/mymoto/blob/e43ef43db676058d08855588dd52419a3554e336/moto/tests/test_ecr/test_ecr_boto3.py#L18-L21
@@ -212,6 +99,29 @@ class TestGetRefUriForImage:
                 ecr_client,
                 ecr_base_uri="1234567890.ecr.example.aws.com",
                 repository_name="repo_which_does_not_exist",
+                tag="latest",
+                account_id="1234567890",
+            )
+
+    def test_error_if_image_does_not_have_ref_tag(self, ecr_client, region_name):
+        """
+        We cannot get the ref URI of an image if there is no ref tag.
+        """
+        manifest = _create_image_manifest()
+
+        ecr_client.create_repository(repositoryName="example_worker")
+        ecr_client.put_image(
+            registryId="1234567890",
+            repositoryName="example_worker",
+            imageManifest=json.dumps(manifest),
+            imageTag="latest",
+        )
+
+        with pytest.raises(ecr.NoRefTagError):
+            ecr.get_ref_uri_for_image(
+                ecr_client,
+                ecr_base_uri="1234567890.ecr.example.aws.com",
+                repository_name="example_worker",
                 tag="latest",
                 account_id="1234567890",
             )

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -1,7 +1,11 @@
+import hashlib
+import json
+from random import random
 import secrets
 
 import pytest
 
+from deploy import ecr
 from deploy.ecr import EcrImage
 from deploy.exceptions import EcrError
 
@@ -114,3 +118,95 @@ def test_repository_name(ecr_base_uri, repository_name, tag):
     )
 
     assert image.repository_name == repository_name
+
+
+# Taken from https://github.com/rubelw/mymoto/blob/e43ef43db676058d08855588dd52419a3554e336/moto/tests/test_ecr/test_ecr_boto3.py#L18-L21
+def _create_image_digest(contents=None):
+    if not contents:
+        contents = "docker_image{0}".format(int(random() * 10 ** 6))
+    return "sha256:%s" % hashlib.sha256(contents.encode("utf-8")).hexdigest()
+
+
+# Taken from https://github.com/rubelw/mymoto/blob/e43ef43db676058d08855588dd52419a3554e336/moto/tests/test_ecr/test_ecr_boto3.py#L24-L52
+def _create_image_manifest():
+    return {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "config": {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": 7023,
+            "digest": _create_image_digest("config"),
+        },
+        "layers": [
+            {
+                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                "size": 32654,
+                "digest": _create_image_digest("layer1"),
+            },
+            {
+                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                "size": 16724,
+                "digest": _create_image_digest("layer2"),
+            },
+            {
+                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                "size": 73109,
+                # randomize image digest
+                "digest": _create_image_digest(),
+            },
+        ],
+    }
+
+
+class TestDescribeImage:
+    def test_describe_nonexistent_image_is_none(self, ecr_client):
+        """
+        Looking up an image that doesn't exist, in a repository that does,
+        returns None.
+        """
+        ecr_client.create_repository(repositoryName="uk.ac.wellcome/example_worker")
+
+        resp = ecr.describe_image(
+            ecr_client,
+            ecr_base_uri="1234567890.ecr.example.aws.com",
+            namespace="uk.ac.wellcome",
+            image_id="example_worker",
+            tag="latest",
+            account_id="1234567890",
+        )
+
+        assert resp is None
+
+    def test_describe_image(self, ecr_client, region_name):
+        """
+        We can store an image in ECR, then retrieve it with describe_image.
+        """
+        manifest = _create_image_manifest()
+
+        ecr_client.create_repository(repositoryName="uk.ac.wellcome/example_worker")
+        ecr_client.put_image(
+            registryId="1234567890",
+            repositoryName="uk.ac.wellcome/example_worker",
+            imageManifest=json.dumps(manifest),
+            imageTag="latest",
+        )
+        ecr_client.put_image(
+            registryId="1234567890",
+            repositoryName="uk.ac.wellcome/example_worker",
+            imageManifest=json.dumps(manifest),
+            imageTag="ref.123",
+        )
+
+        resp = ecr.describe_image(
+            ecr_client,
+            ecr_base_uri="1234567890.ecr.example.aws.com",
+            namespace="uk.ac.wellcome",
+            image_id="example_worker",
+            tag="latest",
+            account_id="1234567890",
+        )
+
+        assert resp == {
+            "image_id": "example_worker",
+            "ref": "1234567890.ecr.example.aws.com/uk.ac.wellcome/example_worker:ref.123",
+        }

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv = HOME
 
 [testenv:lint]
 deps = flake8
-commands = flake8 --max-line-length 120 --max-complexity 15 scripts src tests
+commands = flake8 --ignore=E501 --max-complexity 15 scripts src tests
 
 [testenv:check_release_file]
 deps =


### PR DESCRIPTION
I started looking at the code for dealing with ECR, and started unravelling how we use this code.

It turns out we have a bunch of code that serialises ECR image tags into ECR image URIs… which we then unpick again when we display the tags to the user in the `show-images` command. This patch simplifies some of this logic. It also adds tests around the code for getting ref tags from ECR, slowly ratcheting up the test coverage!