### PR TITLE
Refactor how we validate config in weco-deploy

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal refactoring to improve testing.  This should have no user-visible effect.

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -111,10 +111,6 @@ class Project:
                 self.config['account_id'] = self.user_details['caller_identity']['account_id']
 
         # Initialise project level vars
-        self.role_arn = self.config['role_arn']
-        self.region_name = self.config['region_name']
-        self.account_id = self.config['account_id']
-        self.namespace = self.config['namespace']
         self.image_repositories = self.config.get('image_repositories', [])
 
         # Create required services
@@ -130,6 +126,22 @@ class Project:
     @property
     def id(self):
         return self.config["id"]
+
+    @property
+    def role_arn(self):
+        return self.config["role_arn"]
+
+    @property
+    def region_name(self):
+        return self.config["region_name"]
+
+    @property
+    def account_id(self):
+        return self.config["account_id"]
+
+    @property
+    def namespace(self):
+        return self.config["namespace"]
 
     def _ecr(self, account_id=None, region_name=None, role_arn=None):
         return Ecr(

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -93,8 +93,6 @@ class Project:
             role_arn=self.role_arn
         )
 
-        self.prepared_releases = {}
-
         # Ensure release store is available
         self.releases_store.initialise()
 

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -89,8 +89,6 @@ def prepare_config(config, namespace=None, role_arn=None, region_name=None):
 
 class Project:
     def __init__(self, project_id, config, account_id=None, **kwargs):
-        self.id = project_id
-
         prepare_config(config, **kwargs)
         self.config = config
 
@@ -128,6 +126,10 @@ class Project:
 
         # Ensure release store is available
         self.releases_store.initialise()
+
+    @property
+    def id(self):
+        return self.config["id"]
 
     def _ecr(self, account_id=None, region_name=None, role_arn=None):
         return Ecr(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,7 +1,9 @@
+import secrets
+
 import pytest
 
 from deploy.exceptions import ConfigError
-from deploy.project import Projects, Project
+from deploy.project import prepare_config, Projects, Project
 
 
 def test_loading_non_existent_project_is_runtimeerror(tmpdir):
@@ -18,7 +20,150 @@ def test_loading_non_existent_project_is_runtimeerror(tmpdir):
 
 def test_no_role_arn_is_error():
     with pytest.raises(ConfigError, match="role_arn is not set!"):
-        Project(
-            project_id="my_project",
-            config={}
-        )
+        Project(project_id="my_project", config={})
+
+
+@pytest.fixture()
+def role_arn():
+    return f"arn:aws:iam::1234567890:role/role-{secrets.token_hex()}"
+
+
+class TestPrepareConfig:
+    def test_uses_config_namespace(self, role_arn):
+        """
+        ProjectConfig uses the namespace in the initial config.
+        """
+        config = {"namespace": "edu.self", "role_arn": role_arn}
+        prepare_config(config)
+        assert config["namespace"] == "edu.self"
+
+    def test_allows_overriding_namespace(self, role_arn):
+        """
+        If there is no namespace in the initial config, but an override namespace
+        is supplied, that namespace is added to the config.
+        """
+        config = {"role_arn": role_arn}
+        prepare_config(config, namespace="edu.self")
+        assert config["namespace"] == "edu.self"
+
+    def test_uses_default_namespace(self, role_arn):
+        """
+        If there is no namespace in the initial config, and no override is supplied,
+        then the default namespace is added to the config.
+        """
+        config = {"role_arn": role_arn}
+        prepare_config(config)
+        assert config["namespace"] == "uk.ac.wellcome"
+
+    def test_warns_if_namespace_conflict(self, role_arn):
+        """
+        If there is a namespace in the initial config, and a different override
+        is supplied, then a warning is shown.
+        """
+        config = {"namespace": "edu.self", "role_arn": role_arn}
+        with pytest.warns(UserWarning, match="Preferring override"):
+            prepare_config(config, namespace="uk.ac.wellcome")
+
+        assert config["namespace"] == "uk.ac.wellcome"
+
+    def test_does_not_warn_if_namespace_match(self, role_arn):
+        """
+        If there is a namespace in the initial config, and it matches the override,
+        then no warning is shown.
+        """
+        config = {"namespace": "edu.self", "role_arn": role_arn}
+
+        with pytest.warns(None) as record:
+            prepare_config(config, namespace="edu.self")
+
+        assert len(record) == 0
+
+    def test_allows_overriding_role_arn(self, role_arn):
+        """
+        If there is no role_arn in the initial config, but an override role_arn
+        is supplied, that role_arn is added to the config.
+        """
+        config = {}
+        prepare_config(config, role_arn=role_arn)
+        assert config["role_arn"] == role_arn
+
+    def test_warns_if_role_arn_conflict(self, role_arn):
+        """
+        If there is a role_arn in the initial config, and a differnet override
+        is supplied, then a warning is shown.
+        """
+        config = {"role_arn": role_arn}
+
+        with pytest.warns(UserWarning, match="Preferring override role_arn"):
+            prepare_config(config, role_arn=role_arn + "_alt")
+
+        assert config["role_arn"] == role_arn + "_alt"
+
+    def test_does_not_warn_if_role_arn_match(self, role_arn):
+        """
+        If there is a role_arn in the initial config, and it matches the override,
+        then no warning is shown.
+        """
+        config = {"role_arn": role_arn}
+
+        with pytest.warns(None) as record:
+            prepare_config(config, role_arn=role_arn)
+
+        assert len(record) == 0
+
+    def test_errors_if_no_role_arn(self, role_arn):
+        """
+        If there is no role_arn in the initial config or override, then an
+        error is thrown.
+        """
+        with pytest.raises(ConfigError, match="role_arn is not set"):
+            prepare_config(config={})
+
+    def test_uses_config_region_name(self, role_arn):
+        """
+        ProjectConfig uses the region_name in the initial config.
+        """
+        config = {"region_name": "us-east-2", "role_arn": role_arn}
+        prepare_config(config)
+        assert config["region_name"] == "us-east-2"
+
+    def test_allows_overriding_region_name(self, role_arn):
+        """
+        If there is no region_name in the initial config, but an override region_name
+        is supplied, that region_name is added to the config.
+        """
+        config = {"role_arn": role_arn}
+        prepare_config(config, region_name="eu-north-1")
+        assert config["region_name"] == "eu-north-1"
+
+    def test_uses_default_region_name(self, role_arn):
+        """
+        If there is no region_name in the initial config, and no override is supplied,
+        then the default region_name is added to the config.
+        """
+        config = {"role_arn": role_arn}
+        prepare_config(config)
+        assert config["region_name"] == "eu-west-1"
+
+    def test_warns_if_region_name_conflict(self, role_arn):
+        """
+        If there is a region_name in the initial config, and a different override
+        is supplied, then a warning is shown.
+        """
+        config = {"region_name": "eu-west-1", "role_arn": role_arn}
+        with pytest.warns(UserWarning, match="Preferring override"):
+            prepare_config(config, region_name="us-east-1")
+
+        assert config["region_name"] == "us-east-1"
+
+    def test_does_not_warn_if_region_name_match(self, role_arn):
+        """
+        If there is a region_name in the initial config, and it matches the override,
+        then no warning is shown.
+        """
+        config = {"region_name": "eu-west-1", "role_arn": role_arn}
+
+        with pytest.warns(None) as record:
+            prepare_config(config, region_name="eu-west-1")
+
+        assert len(record) == 0

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -167,3 +167,58 @@ class TestPrepareConfig:
             prepare_config(config, region_name="eu-west-1")
 
         assert len(record) == 0
+
+    def test_duplicate_image_repository_is_error(self, role_arn):
+        """
+        If the same ID appears twice in the list of image repositories, raise
+        a ConfigError.
+        """
+        config = {
+            "role_arn": role_arn,
+            "image_repositories": [
+                {"id": "worker1", "services": []},
+                {"id": "worker1", "services": []},
+                {"id": "worker2", "services": []},
+            ]
+        }
+
+        with pytest.raises(
+            ConfigError, match="Duplicate repo in image_repositories: worker1"
+        ):
+            prepare_config(config)
+
+    def test_duplicate_image_repositories_are_error(self, role_arn):
+        """
+        If the same ID appears twice in the list of image repositories, raise
+        a ConfigError.
+        """
+        config = {
+            "role_arn": role_arn,
+            "image_repositories": [
+                {"id": "worker1", "services": []},
+                {"id": "worker1", "services": []},
+                {"id": "worker2", "services": []},
+                {"id": "worker2", "services": []},
+                {"id": "worker3", "services": []},
+            ]
+        }
+
+        with pytest.raises(
+            ConfigError, match="Duplicate repos in image_repositories: worker1, worker2"
+        ):
+            prepare_config(config)
+
+    def test_does_not_warn_on_unique_image_repositories(self, role_arn):
+        """
+        If all the image repositories have unique IDs, no error is raised.
+        """
+        config = {
+            "role_arn": role_arn,
+            "image_repositories": [
+                {"id": "worker1", "services": []},
+                {"id": "worker2", "services": []},
+                {"id": "worker3", "services": []},
+            ]
+        }
+
+        prepare_config(config)


### PR DESCRIPTION
I'm continuing to refactor my way towards the bit of code where I think deployment checks are failing, but it's somewhat gnarly and I want as good a safety net as possible.

This refactors how we handle the config to make it easier to test, and removes some weird list comprehensions in Project. The list `image_repositories` is really a dict in disguise, so let's treat it that way and simplify some of the downstream code.

Coverage goes from 34% to 38%.