### PR TITLE
Add proper tests for the ReleaseStore class

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,5 @@ include =
 
 [report]
 show_missing = True
+exclude_lines =
+    @abc.abstractmethod

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal refactoring to improve testing.  This should have no user-visible effect.

--- a/src/deploy/release_store.py
+++ b/src/deploy/release_store.py
@@ -1,11 +1,23 @@
 import abc
 
+from botocore.exceptions import ClientError
+
 from . import iam
 
 
 class ReleaseStore(abc.ABC):
     @abc.abstractmethod
     def describe_initialisation(self):
+        """
+        Returns a human-readable string to describe the initialisation process.
+        """
+        pass
+
+    @abc.abstractmethod
+    def initialise(self):
+        """
+        Do any initialisation steps to make the store ready for use.
+        """
         pass
 
 
@@ -16,18 +28,108 @@ class MemoryReleaseStore(ReleaseStore):
     def describe_initialisation(self):
         return "Create in-memory release store"
 
+    def initialise(self):
+        pass
+
 
 class DynamoReleaseStore(ReleaseStore):
     def __init__(self, project_id, region_name, role_arn):
         self.project_id = project_id
-        self.table_name = f"wellcome-releases-{project_id}"
         session = iam.get_session(
             session_name="ReleaseToolDynamoDbReleaseStore",
             role_arn=role_arn,
             region_name=region_name
         )
-        self.dynamo_db = session.resource("dynamodb")
-        self.table = self.dynamo_db.Table(self.table_name)
+        self.dynamodb = session.resource("dynamodb")
+        self.table = self.dynamodb.Table(f"wellcome-releases-{project_id}")
+
+    @property
+    def table_name(self):
+        return self.table.name
 
     def describe_initialisation(self):
         return f"Create DynamoDB table {self.table_name}"
+
+    def initialise(self):
+        # Attempt to load the description of the table from DynamoDB.  If this
+        # fails, we know the table doesn't exist yet and we should try to
+        # create it.
+        try:
+            self.table.load()
+        except self.dynamodb.meta.client.exceptions.ResourceNotFoundException:
+            self._create_table()
+
+    def _create_table(self):
+        self.dynamodb.create_table(
+            TableName=self.table_name,
+            KeySchema=[
+                {
+                    'AttributeName': 'release_id',
+                    'KeyType': 'HASH'
+                }
+            ],
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'release_id',
+                    'AttributeType': 'S'
+                },
+                {
+                    'AttributeName': 'project_id',
+                    'AttributeType': 'S'
+                },
+                {
+                    'AttributeName': 'date_created',
+                    'AttributeType': 'S'
+                },
+                {
+                    'AttributeName': 'last_date_deployed',
+                    'AttributeType': 'S'
+                }
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    'IndexName': 'project_gsi',
+                    'KeySchema': [
+                        {
+                            'AttributeName': 'project_id',
+                            'KeyType': 'HASH'
+                        },
+                        {
+                            'AttributeName': 'date_created',
+                            'KeyType': 'RANGE'
+                        },
+                    ],
+                    'Projection': {
+                        'ProjectionType': 'ALL'
+                    },
+                    'ProvisionedThroughput': {
+                        'ReadCapacityUnits': 1,
+                        'WriteCapacityUnits': 1
+                    }
+                },
+                {
+                    'IndexName': 'deployment_gsi',
+                    'KeySchema': [
+                        {
+                            'AttributeName': 'project_id',
+                            'KeyType': 'HASH'
+                        },
+                        {
+                            'AttributeName': 'last_date_deployed',
+                            'KeyType': 'RANGE'
+                        },
+                    ],
+                    'Projection': {
+                        'ProjectionType': 'ALL'
+                    },
+                    'ProvisionedThroughput': {
+                        'ReadCapacityUnits': 1,
+                        'WriteCapacityUnits': 1
+                    }
+                }
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 1,
+                'WriteCapacityUnits': 1
+            }
+        )

--- a/src/deploy/release_store.py
+++ b/src/deploy/release_store.py
@@ -1,7 +1,6 @@
 import abc
 
 from boto3.dynamodb.conditions import Key
-from botocore.exceptions import ClientError
 
 from . import iam
 from .exceptions import WecoDeployError

--- a/src/deploy/release_store.py
+++ b/src/deploy/release_store.py
@@ -1,8 +1,22 @@
 import abc
 
+from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 
 from . import iam
+from .exceptions import WecoDeployError
+
+
+class ReleaseStoreError(WecoDeployError):
+    pass
+
+
+class ReleaseNotFoundError(ReleaseStoreError):
+    """
+    Raised if a release store is asked to retrieve a release ID which does not exist.
+    """
+
+    pass
 
 
 class ReleaseStore(abc.ABC):
@@ -20,6 +34,33 @@ class ReleaseStore(abc.ABC):
         """
         pass
 
+    @abc.abstractmethod
+    def put_release(self, release):
+        """
+        Store a new release.  Returns None.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_release(self, release_id):
+        """
+        Retrieve a previously stored release.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_recent_releases(self, count):
+        """
+        Return the most recent ``count`` releases, as sorted by creation date.
+        """
+        pass
+
+    def get_most_recent_release(self):
+        """
+        Return the most recent release, as sorted by creation date.
+        """
+        return self.get_recent_releases(count=1)[0]
+
 
 class MemoryReleaseStore(ReleaseStore):
     def __init__(self):
@@ -31,6 +72,23 @@ class MemoryReleaseStore(ReleaseStore):
     def initialise(self):
         pass
 
+    def put_release(self, release):
+        self.cache[release["release_id"]] = release
+
+    def get_release(self, release_id):
+        try:
+            return self.cache[release_id]
+        except KeyError:
+            raise ReleaseNotFoundError(release_id)
+
+    def get_recent_releases(self, count):
+        sorted_releases = sorted(
+            self.cache.values(),
+            key=lambda c: c["date_created"],
+            reverse=True
+        )
+        return sorted_releases[:count]
+
 
 class DynamoReleaseStore(ReleaseStore):
     def __init__(self, project_id, region_name, role_arn):
@@ -38,7 +96,7 @@ class DynamoReleaseStore(ReleaseStore):
         session = iam.get_session(
             session_name="ReleaseToolDynamoDbReleaseStore",
             role_arn=role_arn,
-            region_name=region_name
+            region_name=region_name,
         )
         self.dynamodb = session.resource("dynamodb")
         self.table = self.dynamodb.Table(f"wellcome-releases-{project_id}")
@@ -58,6 +116,32 @@ class DynamoReleaseStore(ReleaseStore):
             self.table.load()
         except self.dynamodb.meta.client.exceptions.ResourceNotFoundException:
             self._create_table()
+
+    def put_release(self, release):
+        self.table.put_item(Item=release)
+
+    def get_release(self, release_id):
+        resp = self.table.get_item(Key={"release_id": release_id})
+        try:
+            return resp["Item"]
+        except KeyError:
+            raise ReleaseNotFoundError(release_id)
+
+    def get_recent_releases(self, count):
+        # The GSI project_gsi uses date_created as a range key, so we can
+        # sort by the contents of this column.
+        query_resp = self.table.query(
+            IndexName="project_gsi",
+            ScanIndexForward=False,
+            Limit=count,
+            # Note: as far as I know, this expression is a no-op -- everything
+            # in a given table will have the same release ID.  We need to have
+            # a KeyConditionExpression for a Query to work, and we need a Query
+            # to get the sorting.
+            KeyConditionExpression=Key("project_id").eq(self.project_id),
+        )
+
+        return query_resp["Items"]
 
     def _create_table(self):
         self.dynamodb.create_table(

--- a/src/deploy/release_store.py
+++ b/src/deploy/release_store.py
@@ -1,0 +1,33 @@
+import abc
+
+from . import iam
+
+
+class ReleaseStore(abc.ABC):
+    @abc.abstractmethod
+    def describe_initialisation(self):
+        pass
+
+
+class MemoryReleaseStore(ReleaseStore):
+    def __init__(self):
+        self.cache = {}
+
+    def describe_initialisation(self):
+        return "Create in-memory release store"
+
+
+class DynamoReleaseStore(ReleaseStore):
+    def __init__(self, project_id, region_name, role_arn):
+        self.project_id = project_id
+        self.table_name = f"wellcome-releases-{project_id}"
+        session = iam.get_session(
+            session_name="ReleaseToolDynamoDbReleaseStore",
+            role_arn=role_arn,
+            region_name=region_name
+        )
+        self.dynamo_db = session.resource("dynamodb")
+        self.table = self.dynamo_db.Table(self.table_name)
+
+    def describe_initialisation(self):
+        return f"Create DynamoDB table {self.table_name}"

--- a/src/deploy/releases_store.py
+++ b/src/deploy/releases_store.py
@@ -2,8 +2,8 @@ from .release_store import DynamoReleaseStore
 
 
 class DynamoDbReleaseStore:
-    def __init__(self, **kwargs):
-        self._underlying = DynamoReleaseStore(project_id)
+    def __init__(self, project_id, **kwargs):
+        self._underlying = DynamoReleaseStore(project_id, **kwargs)
 
     def describe_initialisation(self):
         return self._underlying.describe_initialisation()

--- a/src/deploy/releases_store.py
+++ b/src/deploy/releases_store.py
@@ -1,224 +1,39 @@
-from botocore.exceptions import ClientError
-from boto3.dynamodb.conditions import Key
-
-from . import iam
+from .release_store import DynamoReleaseStore
 
 
 class DynamoDbReleaseStore:
-    def __init__(self, project_id, region_name, role_arn):
-        self.project_id = project_id
-        self.table_name = f"wellcome-releases-{project_id}"
-        self.session = iam.get_session(
-            session_name="ReleaseToolDynamoDbReleaseStore",
-            role_arn=role_arn,
-            region_name=region_name
-        )
-        self.dynamo_db = self.session.resource("dynamodb")
-        self.table = self.dynamo_db.Table(self.table_name)
+    def __init__(self, **kwargs):
+        self._underlying = DynamoReleaseStore(project_id)
 
     def describe_initialisation(self):
+        return self._underlying.describe_initialisation()
         return f"Create DynamoDb table {self.table_name}"
 
     def initialise(self):
-        try:
-            self.table.table_status
-        except ClientError as client_error:
-            if client_error.response['Error']['Code'] == 'ResourceNotFoundException':
-                self._create_table()
-            else:
-                raise (
-                    f"Unknown exception occurred while querying for {self.table_name} {client_error.response}"
-                )
+        return self._underlying.initialise()
 
     def put_release(self, release):
-        self.table.put_item(Item=release)
-
-        return release
+        return self._underlying.put_release()
 
     def get_latest_release(self):
-        items = self.table.query(IndexName='project_gsi',
-                                 KeyConditionExpression=Key('project_id').eq(self.project_id),
-                                 ScanIndexForward=False,
-                                 Limit=1)
-        if items['Count'] == 1:
-            return items['Items'][0]
-        else:
-            return None
+        return self._underlying.get_most_recent_release()
 
     def get_latest_releases(self, limit=1):
-        items = self.table.query(IndexName='project_gsi',
-                                 KeyConditionExpression=Key('project_id').eq(self.project_id),
-                                 ScanIndexForward=False,
-                                 Limit=limit)
-        return items['Items']
+        return self._underlying.get_recent_releases(count=limit)
 
     def get_release(self, release_id):
-        try:
-            return self.table.get_item(Key={"release_id": release_id})["Item"]
-        except KeyError:
-            raise RuntimeError(f"No such release: {release_id}")
+        return self._underlying.get_release(release_id=release_id)
 
     def get_recent_deployments(self, environment_id=None, limit=10):
         """
         Returns the N most recent deployments.
         """
-        known_deployments = []
-
-        resp = self.table.query(
-            IndexName='deployment_gsi',
-            KeyConditionExpression=Key('project_id').eq(self.project_id),
-            Limit=limit,
-            # Query results are always sorted by the sort key value.  Setting
-            # this parameter to False means they are returned in descending order,
-            # i.e. newer deployments come first.
-            #
-            # The sort key on this GSI is last_date_deployed.
-            ScanIndexForward=False,
+        return self._underlying.get_recent_deployments(
+            environment=environment_id, count=limit
         )
-
-        for release in resp["Items"]:
-            for deployment in release["deployments"]:
-                deployment["release_id"] = release["release_id"]
-
-                # Filter on environment_id - this does not play well with filter
-                # resulting in fewer than expected items (this filters on top of
-                # the limit) but it's hard to do better with the data structured
-                # as it is.
-                if environment_id:
-                    if deployment["environment"] == environment_id:
-                        known_deployments.append(deployment)
-                else:
-                    known_deployments.append(deployment)
-
-        known_deployments = sorted(
-            known_deployments, key=lambda d: d["date_created"], reverse=True
-        )
-
-        # We then truncate the list to the limit, otherwise we might be
-        # presenting an incomplete list of deployments.
-        #
-        # Consider:
-        #
-        #   - Release A
-        #       deployed @ 1pm
-        #       deployed @ 6pm
-        #   - Release B
-        #       deployed @ 2pm
-        #   - Release C
-        #       deployed @ 5pm
-        #
-        # If we requested limit=2, then DynamoDB would return the releases
-        # with the two most recent "last_date_deployed" fields.  This would
-        # present the following timeline:
-        #
-        #   - 1pm: Release A
-        #   - 5pm: Release C
-        #   - 6pm: Release A
-        #
-        # What happened to release B???
-        #
-        # We know we have the last N deployments with no gaps, but beyond
-        # that we can't be sure.
-        return known_deployments[:limit]
 
     def add_deployment(self, release_id, deployment, dry_run=False):
         if not dry_run:
-            self.table.update_item(
-                Key={
-                    'release_id': release_id
-                },
-                UpdateExpression="SET #deployments = list_append(#deployments, :d)",
-                ExpressionAttributeNames={
-                    '#deployments': 'deployments',
-                },
-                ExpressionAttributeValues={
-                    ':d': [deployment],
-                }
+            return self._underlying.add_deployment(
+                release_id=release_id, deployment=deployment
             )
-
-            self.table.update_item(
-                Key={
-                    'release_id': release_id
-                },
-                UpdateExpression="SET last_date_deployed = :d",
-                ExpressionAttributeValues={
-                    ':d': deployment['date_created'],
-                }
-            )
-
-        return release_id
-
-    def _create_table(self):
-        self.dynamo_db.create_table(
-            TableName=self.table_name,
-            KeySchema=[
-                {
-                    'AttributeName': 'release_id',
-                    'KeyType': 'HASH'
-                }
-            ],
-            AttributeDefinitions=[
-                {
-                    'AttributeName': 'release_id',
-                    'AttributeType': 'S'
-                },
-                {
-                    'AttributeName': 'project_id',
-                    'AttributeType': 'S'
-                },
-                {
-                    'AttributeName': 'date_created',
-                    'AttributeType': 'S'
-                },
-                {
-                    'AttributeName': 'last_date_deployed',
-                    'AttributeType': 'S'
-                }
-            ],
-            GlobalSecondaryIndexes=[
-                {
-                    'IndexName': 'project_gsi',
-                    'KeySchema': [
-                        {
-                            'AttributeName': 'project_id',
-                            'KeyType': 'HASH'
-                        },
-                        {
-                            'AttributeName': 'date_created',
-                            'KeyType': 'RANGE'
-                        },
-                    ],
-                    'Projection': {
-                        'ProjectionType': 'ALL'
-                    },
-                    'ProvisionedThroughput': {
-                        'ReadCapacityUnits': 1,
-                        'WriteCapacityUnits': 1
-                    }
-                },
-                {
-                    'IndexName': 'deployment_gsi',
-                    'KeySchema': [
-                        {
-                            'AttributeName': 'project_id',
-                            'KeyType': 'HASH'
-                        },
-                        {
-                            'AttributeName': 'last_date_deployed',
-                            'KeyType': 'RANGE'
-                        },
-                    ],
-                    'Projection': {
-                        'ProjectionType': 'ALL'
-                    },
-                    'ProvisionedThroughput': {
-                        'ReadCapacityUnits': 1,
-                        'WriteCapacityUnits': 1
-                    }
-                }
-            ],
-            ProvisionedThroughput={
-                'ReadCapacityUnits': 1,
-                'WriteCapacityUnits': 1
-            }
-        )

--- a/tests/test_release_store.py
+++ b/tests/test_release_store.py
@@ -1,0 +1,35 @@
+import abc
+import secrets
+
+import moto
+
+from deploy.release_store import DynamoReleaseStore, MemoryReleaseStore
+
+
+class ReleaseStoreTestsMixin:
+    @abc.abstractmethod
+    def create_release_store(self):
+        pass
+
+    def test_description(self):
+        release_store = self.create_release_store()
+        description = release_store.describe_initialisation()
+        assert isinstance(description, str)
+        assert len(description) > 0
+
+
+class TestMemoryReleaseStore(ReleaseStoreTestsMixin):
+    def create_release_store(self):
+        return MemoryReleaseStore()
+
+
+class TestDynamoReleaseStore(ReleaseStoreTestsMixin):
+    @moto.mock_iam()
+    @moto.mock_sts()
+    @moto.mock_dynamodb()
+    def create_release_store(self):
+        return DynamoReleaseStore(
+            project_id=f"test_project-{secrets.token_hex()}",
+            region_name="eu-west-1",
+            role_arn="arn:aws:iam::0123456789:role/example_role"
+        )

--- a/tests/test_release_store.py
+++ b/tests/test_release_store.py
@@ -2,7 +2,6 @@ import abc
 import contextlib
 import datetime
 import secrets
-import uuid
 
 from botocore.exceptions import ParamValidationError
 import moto
@@ -95,11 +94,11 @@ class ReleaseStoreTestsMixin:
                     "date_created": datetime.datetime.now().isoformat(),
                     "last_date_deployed": datetime.datetime.now().isoformat(),
                     "deployments": [
-                        {"id": "1", "environment": "prod",    "date_created": datetime.datetime(2001, 1, 1).isoformat()},
-                        {"id": "2", "environment": "prod",    "date_created": datetime.datetime(2001, 1, 2).isoformat()},
-                        {"id": "3", "environment": "staging", "date_created": datetime.datetime(2001, 1, 3).isoformat()},
-                        {"id": "4", "environment": "prod",    "date_created": datetime.datetime(2001, 1, 4).isoformat()},
-                        {"id": "5", "environment": "staging", "date_created": datetime.datetime(2001, 1, 5).isoformat()},
+                        {"id": "1", "date_created": datetime.datetime(2001, 1, 1).isoformat(), "environment": "prod"},
+                        {"id": "2", "date_created": datetime.datetime(2001, 1, 2).isoformat(), "environment": "prod"},
+                        {"id": "3", "date_created": datetime.datetime(2001, 1, 3).isoformat(), "environment": "staging"},
+                        {"id": "4", "date_created": datetime.datetime(2001, 1, 4).isoformat(), "environment": "prod"},
+                        {"id": "5", "date_created": datetime.datetime(2001, 1, 5).isoformat(), "environment": "staging"},
                     ]
                 },
                 {
@@ -108,11 +107,11 @@ class ReleaseStoreTestsMixin:
                     "date_created": datetime.datetime.now().isoformat(),
                     "last_date_deployed": datetime.datetime.now().isoformat(),
                     "deployments": [
-                        {"id": "6", "environment": "prod",     "date_created": datetime.datetime(2001, 1, 6).isoformat()},
-                        {"id": "7", "environment": "prod",     "date_created": datetime.datetime(2001, 1, 7).isoformat()},
-                        {"id": "8", "environment": "staging",  "date_created": datetime.datetime(2001, 1, 8).isoformat()},
-                        {"id": "9", "environment": "prod",     "date_created": datetime.datetime(2001, 1, 9).isoformat()},
-                        {"id": "10", "environment": "staging", "date_created": datetime.datetime(2001, 1, 10).isoformat()},
+                        {"id": "6", "date_created": datetime.datetime(2001, 1, 6).isoformat(), "environment": "prod"},
+                        {"id": "7", "date_created": datetime.datetime(2001, 1, 7).isoformat(), "environment": "prod"},
+                        {"id": "8", "date_created": datetime.datetime(2001, 1, 8).isoformat(), "environment": "staging"},
+                        {"id": "9", "date_created": datetime.datetime(2001, 1, 9).isoformat(), "environment": "prod"},
+                        {"id": "10", "date_created": datetime.datetime(2001, 1, 10).isoformat(), "environment": "staging"},
                     ]
                 },
             ]

--- a/tests/test_release_store.py
+++ b/tests/test_release_store.py
@@ -1,35 +1,55 @@
 import abc
+import contextlib
 import secrets
 
+from botocore.exceptions import ParamValidationError
 import moto
+import pytest
 
 from deploy.release_store import DynamoReleaseStore, MemoryReleaseStore
 
 
 class ReleaseStoreTestsMixin:
     @abc.abstractmethod
+    @contextlib.contextmanager
     def create_release_store(self):
         pass
 
     def test_description(self):
-        release_store = self.create_release_store()
-        description = release_store.describe_initialisation()
-        assert isinstance(description, str)
-        assert len(description) > 0
+        with self.create_release_store() as release_store:
+            description = release_store.describe_initialisation()
+            assert isinstance(description, str)
+            assert len(description) > 0
+
+    def test_can_initialise(self):
+        with self.create_release_store() as release_store:
+            release_store.initialise()
+
+            # Calling initialise() a second time should have no effect
+            release_store.initialise()
 
 
 class TestMemoryReleaseStore(ReleaseStoreTestsMixin):
+    @contextlib.contextmanager
     def create_release_store(self):
-        return MemoryReleaseStore()
+        yield MemoryReleaseStore()
 
 
 class TestDynamoReleaseStore(ReleaseStoreTestsMixin):
-    @moto.mock_iam()
-    @moto.mock_sts()
-    @moto.mock_dynamodb()
+    @contextlib.contextmanager
     def create_release_store(self):
-        return DynamoReleaseStore(
-            project_id=f"test_project-{secrets.token_hex()}",
-            region_name="eu-west-1",
-            role_arn="arn:aws:iam::0123456789:role/example_role"
-        )
+        with moto.mock_dynamodb2(), moto.mock_sts(), moto.mock_iam():
+            yield DynamoReleaseStore(
+                project_id=f"test_project-{secrets.token_hex()}",
+                region_name="eu-west-1",
+                role_arn="arn:aws:iam::0123456789:role/example_role"
+            )
+
+    def test_unexpected_error_at_initialisation_is_raised(self):
+        with self.create_release_store() as release_store:
+            release_store.table = release_store.dynamodb.Table("")
+
+            # DynamoDB tables should have non-empty length.  Trying to initialise
+            # a table whose name is the empty string will fail.
+            with pytest.raises(ParamValidationError):
+                release_store.initialise()

--- a/tests/test_release_store.py
+++ b/tests/test_release_store.py
@@ -1,52 +1,108 @@
 import abc
 import contextlib
+import datetime
 import secrets
+import uuid
 
 from botocore.exceptions import ParamValidationError
 import moto
 import pytest
 
-from deploy.release_store import DynamoReleaseStore, MemoryReleaseStore
+from deploy.release_store import DynamoReleaseStore, MemoryReleaseStore, ReleaseNotFoundError
+
+
+@pytest.fixture
+def project_id():
+    return f"project-{secrets.token_hex()}"
 
 
 class ReleaseStoreTestsMixin:
     @abc.abstractmethod
     @contextlib.contextmanager
-    def create_release_store(self):
+    def create_release_store(self, project_id):
         pass
 
-    def test_description(self):
-        with self.create_release_store() as release_store:
+    def test_description(self, project_id):
+        with self.create_release_store(project_id) as release_store:
             description = release_store.describe_initialisation()
             assert isinstance(description, str)
             assert len(description) > 0
 
-    def test_can_initialise(self):
-        with self.create_release_store() as release_store:
+    def test_can_initialise(self, project_id):
+        with self.create_release_store(project_id) as release_store:
             release_store.initialise()
 
             # Calling initialise() a second time should have no effect
             release_store.initialise()
 
+    def test_can_put_and_get_a_release(self, project_id):
+        release = {
+            "release_id": f"release-{secrets.token_hex()}",
+            "project_id": project_id,
+            "date_created": datetime.datetime.now().isoformat(),
+            "last_date_deployed": datetime.datetime.now().isoformat()
+        }
+
+        with self.create_release_store(project_id) as release_store:
+            release_store.initialise()
+
+            assert release_store.put_release(release) is None
+            assert release_store.get_release(release["release_id"]) == release
+
+    def test_cannot_get_a_nonexistent_release(self, project_id):
+        with self.create_release_store(project_id) as release_store:
+            release_store.initialise()
+
+            release_id = f"release-{secrets.token_hex()}"
+            with pytest.raises(ReleaseNotFoundError, match=release_id):
+                release_store.get_release(release_id)
+
+    def test_can_get_recent_releases(self, project_id):
+        releases = [
+            {
+                "release_id": f"release-{i}",
+                "project_id": project_id,
+                "date_created": datetime.datetime(2001, 1, i).isoformat(),
+                "last_date_deployed": datetime.datetime.now().isoformat()
+            }
+            for i in range(1, 10)
+        ]
+
+        with self.create_release_store(project_id) as release_store:
+            release_store.initialise()
+
+            for r in releases:
+                release_store.put_release(r)
+
+            assert release_store.get_recent_releases(count=3) == [
+                releases[-1], releases[-2], releases[-3]
+            ]
+
+            assert release_store.get_recent_releases(count=5) == [
+                releases[-1], releases[-2], releases[-3], releases[-4], releases[-5]
+            ]
+
+            assert release_store.get_most_recent_release() == releases[-1]
+
 
 class TestMemoryReleaseStore(ReleaseStoreTestsMixin):
     @contextlib.contextmanager
-    def create_release_store(self):
+    def create_release_store(self, project_id):
         yield MemoryReleaseStore()
 
 
 class TestDynamoReleaseStore(ReleaseStoreTestsMixin):
     @contextlib.contextmanager
-    def create_release_store(self):
+    def create_release_store(self, project_id):
         with moto.mock_dynamodb2(), moto.mock_sts(), moto.mock_iam():
             yield DynamoReleaseStore(
-                project_id=f"test_project-{secrets.token_hex()}",
+                project_id=project_id,
                 region_name="eu-west-1",
                 role_arn="arn:aws:iam::0123456789:role/example_role"
             )
 
-    def test_unexpected_error_at_initialisation_is_raised(self):
-        with self.create_release_store() as release_store:
+    def test_unexpected_error_at_initialisation_is_raised(self, project_id):
+        with self.create_release_store(project_id) as release_store:
             release_store.table = release_store.dynamodb.Table("")
 
             # DynamoDB tables should have non-empty length.  Trying to initialise


### PR DESCRIPTION
The DynamoDbReleaseStore is a pretty fundamental part of weco-deploy, but was previously untested. We also had no good way of simulating it in tests, which made it hard to test the code in `project.py`.

This patch flips it to the style of our scala-storage classes: a base trait with multiple implementations, including an in-memory implementation we can use for testing other bits of the codebase later.

Coverage: 41% to 49%.