### PR TITLE
Test the show-deployments CLI command, and fix a bug

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Internal refactoring to improve testing, plus fixing bugs in the ``show-deployments`` command.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -461,9 +461,10 @@ def show_release(ctx, release_id):
 
 @cli.command()
 @click.argument('release_id', required=False)
+@click.option('--environment-id', required=False)
 @click.option('--limit', required=False, default=10)
 @click.pass_context
-def show_deployments(ctx, release_id, limit):
+def show_deployments(ctx, release_id, environment_id, limit):
     project = ctx.obj['project']
 
     rows = []
@@ -476,7 +477,11 @@ def show_deployments(ctx, release_id, limit):
         "description"
     ]
 
-    for deployment in project.get_deployments(release_id=release_id, limit=limit):
+    for deployment in project.get_deployments(
+        release_id=release_id,
+        environment_id=environment_id,
+        limit=limit
+    ):
         rows.append(
             [
                 deployment["release_id"],

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -286,10 +286,12 @@ class Project:
         if release_id is not None:
             release = self.release_store.get_release(release_id)
 
+            # TODO: I think the release ID is already stored on the deployments.
+            # Can we remove this loop?
             for d in release["deployments"]:
-                d["release_id"] = release_id
+                assert d["release_id"] == release_id
 
-            deployments = release_id["deployments"]
+            deployments = release["deployments"]
         else:
             deployments = self.release_store.get_recent_deployments(
                 environment_id=environment_id,

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -294,7 +294,7 @@ class Project:
             deployments = release["deployments"]
         else:
             deployments = self.release_store.get_recent_deployments(
-                environment_id=environment_id,
+                environment=environment_id,
                 limit=limit
             )
 
@@ -605,6 +605,9 @@ class Project:
 
         deployment = self._create_deployment(environment_id, deployment_details, description)
 
-        self.release_store.add_deployment(release['release_id'], deployment)
+        self.release_store.add_deployment(
+            release_id=release['release_id'],
+            deployment=deployment
+        )
 
         return deployment

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -151,7 +151,7 @@ def test_show_deployments(project_id, release_store, wellcome_project_file):
         ["--project-file", wellcome_project_file, "show-deployments"]
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert len(result.output.splitlines()) == 7  # 2 header + 5 deployments
     assert "No description provided" not in result.output
 
@@ -161,7 +161,7 @@ def test_show_deployments(project_id, release_store, wellcome_project_file):
         ["--project-file", wellcome_project_file, "show-deployments", "release-1"]
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert len(result.output.splitlines()) == 4  # 2 header + 2 deployments
     assert "release-2" not in result.output
 
@@ -171,5 +171,14 @@ def test_show_deployments(project_id, release_store, wellcome_project_file):
         ["--project-file", wellcome_project_file, "show-deployments", "--limit=3"]
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert len(result.output.splitlines()) == 5  # 2 header + 3 deployments
+
+    # Check that we can filter by environment
+    result = runner.invoke(
+        cli,
+        ["--project-file", wellcome_project_file, "show-deployments", "--environment-id=staging"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(result.output.splitlines()) == 3  # 2 header + 1 deployment

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -129,6 +129,13 @@ def test_show_deployments(project_id, release_store, wellcome_project_file):
                     "requested_by": "role/prod-ops",
                     "description": "Redeploy to prod",
                 },
+                {
+                    "release_id": "release-2",
+                    "environment": "prod",
+                    "date_created": datetime.datetime(2002, 2, 3).isoformat(),
+                    "requested_by": "role/staging-peeps",
+                    "description": "No description provided",
+                },
             ]
         },
     ]
@@ -145,4 +152,24 @@ def test_show_deployments(project_id, release_store, wellcome_project_file):
     )
 
     assert result.exit_code == 0
-    assert len(result.output.splitlines()) == 6  # 2 header + 4 deployments
+    assert len(result.output.splitlines()) == 7  # 2 header + 5 deployments
+    assert "No description provided" not in result.output
+
+    # Check that we can see the deployments for a particular release
+    result = runner.invoke(
+        cli,
+        ["--project-file", wellcome_project_file, "show-deployments", "release-1"]
+    )
+
+    assert result.exit_code == 0
+    assert len(result.output.splitlines()) == 4  # 2 header + 2 deployments
+    assert "release-2" not in result.output
+
+    # Check that we can limit the number of deployments
+    result = runner.invoke(
+        cli,
+        ["--project-file", wellcome_project_file, "show-deployments", "--limit=3"]
+    )
+
+    assert result.exit_code == 0
+    assert len(result.output.splitlines()) == 5  # 2 header + 3 deployments

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -83,3 +83,66 @@ def test_show_release(project_id, release_store, wellcome_project_file):
 
     assert result.exit_code == 0, result.output
     assert json.loads(result.output) == releases[0]
+
+
+def test_show_deployments(project_id, release_store, wellcome_project_file):
+    releases = [
+        {
+            "release_id": "release-1",
+            "project_id": project_id,
+            "date_created": datetime.datetime(2001, 1, 1).isoformat(),
+            "last_date_deployed": datetime.datetime.now().isoformat(),
+            "deployments": [
+                {
+                    "release_id": "release-1",
+                    "environment": "prod",
+                    "date_created": datetime.datetime(2001, 1, 1).isoformat(),
+                    "requested_by": "role/prod-ops",
+                    "description": "No description provided",
+                },
+                {
+                    "release_id": "release-1",
+                    "environment": "staging",
+                    "date_created": datetime.datetime(2001, 1, 2).isoformat(),
+                    "requested_by": "role/staging-peeps",
+                    "description": "Deploy release 1 to staging",
+                },
+            ]
+        },
+        {
+            "release_id": "release-2",
+            "project_id": project_id,
+            "date_created": datetime.datetime(2002, 2, 1).isoformat(),
+            "last_date_deployed": datetime.datetime.now().isoformat(),
+            "deployments": [
+                {
+                    "release_id": "release-2",
+                    "environment": "prod",
+                    "date_created": datetime.datetime(2002, 2, 1).isoformat(),
+                    "requested_by": "role/prod-ops",
+                    "description": "No description provided",
+                },
+                {
+                    "release_id": "release-2",
+                    "environment": "prod",
+                    "date_created": datetime.datetime(2002, 2, 2).isoformat(),
+                    "requested_by": "role/prod-ops",
+                    "description": "Redeploy to prod",
+                },
+            ]
+        },
+    ]
+
+    for r in releases:
+        release_store.put_release(r)
+
+    runner = CliRunner()
+
+    # Check that we can see a list of deployments
+    result = runner.invoke(
+        cli,
+        ["--project-file", wellcome_project_file, "show-deployments"]
+    )
+
+    assert result.exit_code == 0
+    assert len(result.output.splitlines()) == 6  # 2 header + 4 deployments

--- a/tests/test_release_store.py
+++ b/tests/test_release_store.py
@@ -73,11 +73,11 @@ class ReleaseStoreTestsMixin:
             for r in releases:
                 release_store.put_release(r)
 
-            assert release_store.get_recent_releases(count=3) == [
+            assert release_store.get_recent_releases(limit=3) == [
                 releases[-1], releases[-2], releases[-3]
             ]
 
-            assert release_store.get_recent_releases(count=5) == [
+            assert release_store.get_recent_releases(limit=5) == [
                 releases[-1], releases[-2], releases[-3], releases[-4], releases[-5]
             ]
 
@@ -126,22 +126,22 @@ class ReleaseStoreTestsMixin:
             for r in releases:
                 release_store.put_release(r)
 
-            resp = release_store.get_recent_deployments(count=0)
+            resp = release_store.get_recent_deployments(limit=0)
             assert resp == []
 
-            resp = release_store.get_recent_deployments(count=4)
+            resp = release_store.get_recent_deployments(limit=4)
             assert [d["id"] for d in resp] == ["10", "9", "8", "7"]
 
-            resp = release_store.get_recent_deployments(count=6)
+            resp = release_store.get_recent_deployments(limit=6)
             assert [d["id"] for d in resp] == ["10", "9", "8", "7", "6", "5"]
 
             resp = release_store.get_recent_deployments(environment="staging")
             assert [d["id"] for d in resp] == ["10", "8", "5", "3"]
 
-            resp = release_store.get_recent_deployments(environment="staging", count=4)
+            resp = release_store.get_recent_deployments(environment="staging", limit=4)
             assert [d["id"] for d in resp] == ["10", "8", "5", "3"]
 
-            resp = release_store.get_recent_deployments(count=1, environment="prod")
+            resp = release_store.get_recent_deployments(environment="prod", limit=1)
             assert [d["id"] for d in resp] == ["9"]
 
     def test_can_add_deployment(self, project_id):


### PR DESCRIPTION
Turns out `show-deployments` got busted in a recent refactoring. Now it's fixed, and tested! (Sort of – it checks the lines are broadly correct, but I don't check the exact output because that feels brittle.)