### PR TITLE
Publish weco-deploy to ECR as well as Docker Hub

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+weco-deploy is now published to our private ECR registry as well as Docker Hub.


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/4879

We can mirror it, but given how frequently we cut new versions it's better to have it publish all the new versions to ECR automatically.