### PR TITLE
Fix prepare and deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/python:3.7-alpine
 
 LABEL maintainer = "Wellcome Collection <dev@wellcomecollection.org>"
 LABEL description = "A Docker image for deploying our Docker images to AWS"

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix inability to prepare release, and missing namespace on image_repositories

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -205,15 +205,13 @@ class Project:
         -   account_id
         -   region_name
         -   role_arn
-        -   repository_name
+        -   namespace
         -   services
 
         """
         result = {}
 
         for repo in self.config.get("image_repositories", []):
-            namespace = repo.get("namespace", self.namespace)
-
             # We should have uniqueness by the checks in prepare_config(), but
             # it doesn't hurt to check.
             assert repo["id"] not in result, repo["id"]
@@ -222,7 +220,7 @@ class Project:
                 "account_id": repo.get("account_id", self.account_id),
                 "region_name": repo.get("region_name", self.region_name),
                 "role_arn": repo.get("role_arn", self.role_arn),
-                "repository_name": f"{namespace}/{repo['id']}",
+                "namespace": repo.get("namespace", self.namespace),
                 "services": repo.get("services", []),
             }
 

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -489,7 +489,7 @@ class Project:
         return result
 
     def _prepare_release(self, description, release_images):
-        previous_release = self.release_store.get_latest_release()
+        previous_release = self.release_store.get_most_recent_release()
 
         new_release = self._create_release(
             description=description,

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -547,6 +547,7 @@ class Project:
 
         try:
             matched_image = self.image_repositories[image_id]
+            namespace = matched_image["namespace"]
             ecr = self._ecr(
                 account_id=matched_image["account_id"],
                 region_name=matched_image["region_name"],
@@ -556,9 +557,10 @@ class Project:
             # TODO: Does it make sense to create an ECR client if we don't
             # have an ECR repo to tag in?
             ecr = self._ecr()
+            namespace = self.namespace
 
         return ecr.tag_image(
-            namespace=self.namespace,
+            namespace=namespace,
             image_id=image_id,
             tag=old_tag,
             new_tag=new_tag

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -129,19 +129,16 @@ def test_get_ref_tags_for_repositories(ecr_client, region_name):
             "account_id": "1111111111",
             "region_name": region_name,
             "role_arn": "arn:aws:iam::1111111111:role/example-role",
-            "repository_name": "example_worker1",
         },
         "example_worker2": {
             "account_id": "2222222222",
             "region_name": region_name,
             "role_arn": "arn:aws:iam::2222222222:role/example-role",
-            "repository_name": "example_worker2",
         },
         "example_worker3": {
             "account_id": "3333333333",
             "region_name": region_name,
             "role_arn": "arn:aws:iam::3333333333:role/example-role",
-            "repository_name": "example_worker3",
         },
     }
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -373,21 +373,21 @@ class TestProject:
 
         assert project.image_repositories == {
             "repo1": {
-                "repository_name": "org.wellcome/repo1",
+                "namespace": "org.wellcome",
                 "services": ["service1a", "service1b"],
                 "account_id": "1111111111",
                 "region_name": "us-east-1",
                 "role_arn": "arn:aws:iam::1111111111:role/publisher-role",
             },
             "repo2": {
-                "repository_name": "edu.self/repo2",
+                "namespace": "edu.self",
                 "services": ["service2a", "service2b", "service2c"],
                 "account_id": "1234567890",
                 "region_name": "eu-west-1",
                 "role_arn": role_arn,
             },
             "repo3": {
-                "repository_name": "edu.self/repo3",
+                "namespace": "edu.self",
                 "services": ["service3a"],
                 "account_id": "1234567890",
                 "region_name": "eu-west-1",

--- a/tox.Dockerfile
+++ b/tox.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/python:3.7-alpine
 
 LABEL maintainer = "Wellcome Collection <dev@wellcomecollection.org>"
 LABEL description = "A Docker image for deploying our Python/Tox images to AWS"


### PR DESCRIPTION
This fixes some bugs introduced recently which prevented the tool from being usable.

I would like to put some time into developing some kind of integration tests (ie, automated testing of the actual usage of the tool, rather than of its constituent parts) to prevent this sort of thing happening, as it's really tricky to actually test locally given that one probably doesn't want to deploy anything.

In the mean time, please can we have a freeze on any non-required changes? As you can see in this PR, the bugs that were introduced were non-trivial and were caused by changing components and writing tests for their new behaviour, without testing/changing the usage of these components by the higher-level parts of the tool.

In order to make refactors safe we should be (where possible) writing the tests _before_ we change anything. A good percentage of yesterday was lost to these bugs and I would like to avoid that happening again!