### PR TITLE
Fix docker packaging incorrect version

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Bump to attempt to fix docker packaging incorrect version

--- a/scripts/docker.py
+++ b/scripts/docker.py
@@ -35,10 +35,7 @@ if __name__ == '__main__':
     tools.git('config', 'user.email', 'wellcomedigitalplatform@wellcome.ac.uk')
     tools.add_ssh_origin()
 
-    # Update tags to ensure we can calculate latest version correctly
-    tools.git('fetch')
-
-    # Dockerfile installs from local, ensure it uses latest version
+    # Get latest metadata & code
     tools.git('pull')
 
     HEAD = tools.hash_for_name('HEAD')

--- a/scripts/docker.py
+++ b/scripts/docker.py
@@ -34,7 +34,12 @@ if __name__ == '__main__':
     tools.git('config', 'user.name', 'Buildkite on behalf of Wellcome Collection')
     tools.git('config', 'user.email', 'wellcomedigitalplatform@wellcome.ac.uk')
     tools.add_ssh_origin()
+
+    # Update tags to ensure we can calculate latest version correctly
     tools.git('fetch')
+    
+    # Dockerfile installs from local, ensure it uses latest version
+    tools.git('pull')
 
     HEAD = tools.hash_for_name('HEAD')
     MASTER = tools.hash_for_name('origin/master')

--- a/scripts/docker.py
+++ b/scripts/docker.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
 
     # Update tags to ensure we can calculate latest version correctly
     tools.git('fetch')
-    
+
     # Dockerfile installs from local, ensure it uses latest version
     tools.git('pull')
 


### PR DESCRIPTION
This change pulls latest before packaging weco-deploy in a docker container.

Previously the correct code was packaged, but with an incorrect version identifier.

This issue occurred as the docker packaging step is independent of the version bump step and will not have any changes commited there.