### PR TITLE
Fix for preparing releases to fresh projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,22 @@ correct metadata is available in SSM & ECR
    # To publish the local image "my_service:my_test" to "uk.ac.wellcome/my_service:my_test" in ECR
    weco-deploy publish --image-id my_service --label my_test
 
+Running tests
+~~~~~~~~~~~~~~~~~
+
+To run tests locally you can run the following commands:
+
+::
+
+   # Login to ECR using a profile that will give you write access to ECR in the platform account
+   aws ecr get-login-password --region eu-west-1 --profile platform | docker login \
+      --username AWS \
+      --password-stdin \
+      760097843905.dkr.ecr.eu-west-1.amazonaws.com
+
+   # Run the docker-compose test override
+   docker-compose -f docker-compose.yml -f docker-compose.override.test.yml up
+
 Preparing a release
 ~~~~~~~~~~~~~~~~~~~
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fixes running prepare when there are no releases

--- a/docker-compose.override.test.yml
+++ b/docker-compose.override.test.yml
@@ -1,0 +1,5 @@
+version: "3.3"
+services:
+  tox:
+    environment:
+      - TOXENV=py37

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -10,7 +10,7 @@ from . import ecr, iam
 from .ecr import Ecr
 from .ecs import Ecs
 from .exceptions import ConfigError
-from .release_store import DynamoReleaseStore
+from .release_store import DynamoReleaseStore, ReleaseNotFoundError
 from .tags import parse_aws_tags
 
 DEFAULT_ECR_NAMESPACE = "uk.ac.wellcome"
@@ -500,7 +500,10 @@ class Project:
         return result
 
     def _prepare_release(self, description, release_images):
-        previous_release = self.release_store.get_most_recent_release()
+        try:
+            previous_release = self.release_store.get_most_recent_release()
+        except ReleaseNotFoundError:
+            previous_release = None
 
         new_release = self._create_release(
             description=description,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -485,5 +485,5 @@ class TestProject:
         project.get_images = patch_get_images
         prepared_release = project.prepare("stage", "Some description")
 
-        assert prepared_release["previous_release"] == None
+        assert prepared_release["previous_release"] is None
         assert prepared_release["new_release"]["images"] == get_images_return

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -441,3 +441,49 @@ class TestProject:
 
         for r in releases:
             assert project.get_release(release_id=r["release_id"]) == r
+
+    def test_prepare_no_release_available(self, role_arn, project_id):
+        release_store = MemoryReleaseStore()
+
+        config = {
+            "image_repositories": [
+                {
+                    "id": "repo1",
+                    "services": ["service1"],
+                    "account_id": "1111111111",
+                    "region_name": "us-east-1",
+                    "namespace": "org.wellcome",
+                    "role_arn": "arn:aws:iam::1111111111:role/publisher-role"
+                },
+            ],
+            "environments": [
+                {"id": "stage", "name": "Staging"},
+                {"id": "prod", "name": "Prod"},
+            ],
+            "role_arn": role_arn,
+            "account_id": "1234567890",
+            "namespace": "edu.self",
+            "region_name": "eu-west-1",
+        }
+
+        project = Project(
+            project_id=project_id,
+            config=config,
+            release_store=release_store
+        )
+
+        get_images_return = {
+            "foo": "abc"
+        }
+
+        def patch_get_images(label):
+            return get_images_return
+
+        # This is a poor way to test prepare as it relies on knowing the impl of get_images
+        # The correct way to do this is to have a mocked `Ecr` and hand that in
+        # TODO: Handle tests that interact with ECR by mocking it
+        project.get_images = patch_get_images
+        prepared_release = project.prepare("stage", "Some description")
+
+        assert prepared_release["previous_release"] == None
+        assert prepared_release["new_release"]["images"] == get_images_return


### PR DESCRIPTION
Adds a fix where preparing a release would fail in a new project with no previous releases.

Also adds some documentation / code for running tests locally.