### PR TITLE
Describe the .wellcome_project config in actual models

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Add some models to describe the weco-deploy config.
+
+Note: this release adds a dependency on ``attrs`` and ``cattrs`` (which provide similar typed-models-to-JSON-and-back functionality to case classes and Circe in our Scala apps).

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,5 +1,5 @@
 RELEASE_TYPE: patch
 
-Add some models to describe the weco-deploy config.
+Add some models to describe the weco-deploy config.  These models aren't used yet, but they should make it easier to work on weco-deploy in future.
 
 Note: this release adds a dependency on ``attrs`` and ``cattrs`` (which provide similar typed-models-to-JSON-and-back functionality to case classes and Circe in our Scala apps).

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ with open(local_file('src/deploy/version.py')) as o:
 assert __version__ is not None
 
 install_requires = [
+    "attrs >= 20.3.0",
+    "cattrs >= 1.4.0,<2",
     'click >= 7.1.2',
     'boto3 >= 1.14.18',
     'pyyaml >= 5.3.1',

--- a/src/deploy/iterators.py
+++ b/src/deploy/iterators.py
@@ -1,4 +1,7 @@
+import collections
 import itertools
+
+from .exceptions import ConfigError
 
 
 def chunked_iterable(iterable, *, size):
@@ -15,3 +18,16 @@ def chunked_iterable(iterable, *, size):
         if not chunk:
             break
         yield chunk
+
+
+def convert_identified_list_to_dict(values):
+    """
+    Given a list of objects with a .id parameter, convert them to a dict
+    keyed with the .id.
+    """
+    id_counts = collections.Counter(v.id for v in values)
+    duplicate_ids = {id for id, count in id_counts.items() if count > 1}
+    if duplicate_ids:
+        raise ConfigError("Duplicate IDs: %s" % ", ".join(duplicate_ids))
+
+    return {v.id: v for v in values}

--- a/src/deploy/models.py
+++ b/src/deploy/models.py
@@ -1,0 +1,51 @@
+import typing
+
+import attr
+import cattr
+import yaml
+
+
+@attr.s
+class Environment:
+    id = attr.ib()
+    name = attr.ib()
+
+
+@attr.s
+class Service:
+    id = attr.ib()
+
+
+@attr.s
+class ImageRepository:
+    id = attr.ib()
+    services: typing.List[Service] = attr.ib(factory=list)
+
+
+@attr.s
+class Project:
+    environments: typing.List[Environment] = attr.ib()
+    image_repositories: typing.List[ImageRepository] = attr.ib()
+    name = attr.ib()
+    role_arn = attr.ib()
+
+    account_id = attr.ib(default=None, type=str)
+    aws_region_name = attr.ib(default="eu-west-1")
+
+
+@attr.s
+class ProjectList:
+    projects: typing.Dict[str, Project] = attr.ib()
+
+    @classmethod
+    def from_text(cls, yaml_text):
+        data = yaml.safe_load(yaml_text)
+        return ProjectList(
+            projects=cattr.structure(data, typing.Dict[str, Project])
+        )
+
+    @classmethod
+    def from_path(cls, path):
+        with open(path) as infile:
+            yaml_text = infile.read()
+        return ProjectList.from_text(yaml_text=yaml_text)

--- a/src/deploy/models.py
+++ b/src/deploy/models.py
@@ -1,24 +1,10 @@
-import collections
 import typing
 
 import attr
 import cattr
 import yaml
 
-from .exceptions import ConfigError
-
-
-def _convert_identified_list_to_dict(values):
-    """
-    Given a list of objects with a .id parameter, convert them to a dict
-    keyed with the .id.
-    """
-    id_counts = collections.Counter(v.id for v in values)
-    duplicate_ids = {id for id, count in id_counts.items() if count > 1}
-    if duplicate_ids:
-        raise ConfigError("Duplicate IDs: %s" % ", ".join(duplicate_ids))
-
-    return {v.id: v for v in values}
+from .iterators import convert_identified_list_to_dict
 
 
 @attr.s
@@ -36,17 +22,17 @@ class Service:
 class ImageRepository:
     id = attr.ib()
     services: typing.List[Service] = attr.ib(
-        factory=list, converter=_convert_identified_list_to_dict
+        factory=list, converter=convert_identified_list_to_dict
     )
 
 
 @attr.s
 class Project:
     environments: typing.List[Environment] = attr.ib(
-        converter=_convert_identified_list_to_dict
+        converter=convert_identified_list_to_dict
     )
     image_repositories: typing.List[ImageRepository] = attr.ib(
-        converter=_convert_identified_list_to_dict
+        converter=convert_identified_list_to_dict
     )
     name = attr.ib()
     role_arn = attr.ib()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,6 @@
+import pytest
+
+from deploy.exceptions import ConfigError
 from deploy.models import Environment, ImageRepository, ProjectList, Project, Service
 
 example_wellcome_project = """
@@ -38,19 +41,13 @@ def test_from_path(tmpdir):
             Environment(id="prod", name="Production"),
         ],
         image_repositories=[
-            ImageRepository(
-                id="calm_adapter",
-                services=[Service(id="calm-adapter")]
-            ),
-            ImageRepository(
-                id="calm_deletion_checker",
-                services=[]
-            )
+            ImageRepository(id="calm_adapter", services=[Service(id="calm-adapter")]),
+            ImageRepository(id="calm_deletion_checker", services=[]),
         ],
         name="Calm Adapter",
         role_arn="arn:aws:iam::123456789012:role/platform-ci",
         account_id="123456789012",
-        aws_region_name="us-east-1"
+        aws_region_name="us-east-1",
     )
 
     sierra_adapter = Project(
@@ -65,14 +62,14 @@ def test_from_path(tmpdir):
                     Service(id="bibs-merger"),
                     Service(id="items-merger"),
                     Service(id="holdings-merger"),
-                ]
+                ],
             )
         ],
         name="Sierra Adapter",
         role_arn="arn:aws:iam::760097843905:role/platform-ci",
         # These are the default values
         account_id=None,
-        aws_region_name="eu-west-1"
+        aws_region_name="eu-west-1",
     )
 
     yaml_path = tmpdir / ".wellcome_project"
@@ -80,9 +77,41 @@ def test_from_path(tmpdir):
 
     project_list = ProjectList.from_path(yaml_path)
 
-    assert project_list == ProjectList(
-        projects={
-            "calm_adapter": calm_adapter,
-            "sierra_adapter": sierra_adapter,
-        }
+    assert project_list == {
+        "calm_adapter": calm_adapter,
+        "sierra_adapter": sierra_adapter,
+    }
+
+    # Check we can look up objects using their ID.
+    assert project_list["calm_adapter"].image_repositories[
+        "calm_adapter"
+    ] == ImageRepository(id="calm_adapter", services=[Service(id="calm-adapter")])
+    assert project_list["calm_adapter"].image_repositories["calm_adapter"].services[
+        "calm-adapter"
+    ] == Service(id="calm-adapter")
+    assert project_list["calm_adapter"].environments["prod"] == Environment(
+        id="prod", name="Production"
     )
+
+
+@pytest.mark.parametrize("bad_yaml", [
+    """
+    example_project:
+      environments:
+        - id: prod
+          name: Production
+        - id: prod
+          name: Production
+        - id: staging
+          name: Staging
+      image_repositories:
+        - id: example_project
+          services:
+            - id: example_project
+      name: Example Project
+      role_arn: arn:aws:iam::123456789012:role/example-ci
+    """
+])
+def test_duplicate_ids(bad_yaml):
+    with pytest.raises(ConfigError, match="Duplicate IDs:"):
+        ProjectList.from_text(bad_yaml)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,88 @@
+from deploy.models import Environment, ImageRepository, ProjectList, Project, Service
+
+example_wellcome_project = """
+calm_adapter:
+  environments:
+    - id: prod
+      name: Production
+  image_repositories:
+    - id: calm_adapter
+      services:
+        - id: calm-adapter
+    - id: calm_deletion_checker
+  name: Calm Adapter
+  role_arn: arn:aws:iam::123456789012:role/platform-ci
+  account_id: 123456789012
+  aws_region_name: us-east-1
+
+sierra_adapter:
+  environments:
+    - id: prod
+      name: Production
+    - id: staging
+      name: Staging
+  image_repositories:
+    - id: sierra_merger
+      services:
+        - id: bibs-merger
+        - id: items-merger
+        - id: holdings-merger
+  name: Sierra Adapter
+  role_arn: arn:aws:iam::760097843905:role/platform-ci
+"""
+
+
+def test_from_path(tmpdir):
+    calm_adapter = Project(
+        environments=[
+            Environment(id="prod", name="Production"),
+        ],
+        image_repositories=[
+            ImageRepository(
+                id="calm_adapter",
+                services=[Service(id="calm-adapter")]
+            ),
+            ImageRepository(
+                id="calm_deletion_checker",
+                services=[]
+            )
+        ],
+        name="Calm Adapter",
+        role_arn="arn:aws:iam::123456789012:role/platform-ci",
+        account_id="123456789012",
+        aws_region_name="us-east-1"
+    )
+
+    sierra_adapter = Project(
+        environments=[
+            Environment(id="prod", name="Production"),
+            Environment(id="staging", name="Staging"),
+        ],
+        image_repositories=[
+            ImageRepository(
+                id="sierra_merger",
+                services=[
+                    Service(id="bibs-merger"),
+                    Service(id="items-merger"),
+                    Service(id="holdings-merger"),
+                ]
+            )
+        ],
+        name="Sierra Adapter",
+        role_arn="arn:aws:iam::760097843905:role/platform-ci",
+        # These are the default values
+        account_id=None,
+        aws_region_name="eu-west-1"
+    )
+
+    yaml_path = tmpdir / ".wellcome_project"
+    yaml_path.write(example_wellcome_project)
+
+    project_list = ProjectList.from_path(yaml_path)
+
+    assert project_list == ProjectList(
+        projects={
+            "calm_adapter": calm_adapter,
+            "sierra_adapter": sierra_adapter,
+        }
+    )


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5112

Some context:

* weco-deploy should be able to publish to public ECR repositories (https://github.com/wellcomecollection/platform/issues/4910).

    This is less important for the catalogue, but would help with the storage-service by getting our images into public repos, and allowing other people to pull and use them.

* The naming structure of public ECR repositories is a bit different to private ones. In particular, rather than pushing to `{account_id}.dkr.ecr.{region_name}.amazonaws.com/{name}`, you push to `public.ecr.aws/{gallery_id}/{name}`:

    <img width="785" alt="Screenshot 2021-04-06 at 08 11 09" src="https://user-images.githubusercontent.com/301220/113672451-b7154600-96af-11eb-98ad-d7930d085a39.png">

   So I'd like to handle this in the `.wellcome_project` config by adding two new keys:

    - `visibility: [private|public]`, which would default to `private` for backwards-compatibility
    - `gallery_id: <str>`, which in this case would be `h9x3i1e2`

    (If you don't like that model, let's discuss it elsewhere – this is an example but not the point of this PR.)

* Adding new fields to `.wellcome_project` – or understanding what it should be – is quite difficult with the current code. We pass around all the config as untyped dicts, add/remove keys on the fly, and following something from the YAML to the code where it's used is quite tricky.

   Thus: types! (And immutability, if enforced by programmers and not the language.)

   This patch adds the `attrs` library (think case classes, but for Python) and `cattrs` (think Circe), and declares some models based on what I think `.wellcome_project` should look like. The plan is that I'll gradually refactor weco-deploy so that it:

    - parses the YAML file as an instance of `ProjectList` (returning a `Dict[str, Project]`)
    - passes those models around internally, and doesn't modify them once they're parsed

    I'll refactor the internals to use these models in subsequent PRs, but I want to sound out the idea before I yank on that thread.

    I'd also like to merge https://github.com/wellcomecollection/weco-deploy/pull/97 first, because it removes some unused fields that I haven't added to these models, and the less state we're modifying/passing around, the better.