### PR TITLE
Remove the account ID and registryId overrides

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,6 @@ following format:
         image_repositories:
         - id: my_service
           namespace: uk.ac.wellcome
-          account_id: '12345678901'
           # Optional service block for automated deployments
           # This tag needs to match the value of ECS service tag "deployment:service"
           services:

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Simplify the code slightly by removing account/registry ID overrides, which we never use in practice.  We always use the default ECR registry.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -26,12 +26,11 @@ LOGGING_ROOT = os.path.join(os.environ["HOME"], ".local", "share", "weco-deploy"
 @click.option('--confirm', '-y', is_flag=True, help="Non-interactive deployment confirmation")
 @click.option("--project-id", '-i', help="Specify the project ID")
 @click.option("--region-name", '-i', help="Specify the AWS region name")
-@click.option("--account-id", help="Specify the AWS account ID")
 @click.option("--namespace", help="Specify the project namespace")
 @click.option("--role-arn", help="Specify an AWS role to assume")
 @click.option('--dry-run', '-d', is_flag=True, help="Don't make changes.")
 @click.pass_context
-def cli(ctx, project_file, verbose, confirm, project_id, region_name, account_id, namespace, role_arn, dry_run):
+def cli(ctx, project_file, verbose, confirm, project_id, region_name, namespace, role_arn, dry_run):
     warn_if_not_latest_version()
 
     try:
@@ -63,7 +62,6 @@ def cli(ctx, project_file, verbose, confirm, project_id, region_name, account_id
         project_id=project_id,
         region_name=region_name,
         role_arn=role_arn,
-        account_id=account_id,
         namespace=namespace
     )
 
@@ -82,7 +80,6 @@ def cli(ctx, project_file, verbose, confirm, project_id, region_name, account_id
             f"IN region:        {config['region_name']}",
             f"Running as role:  {user_arn}",
             f"Underlying role:  {underlying_user_arn}" if user_arn != underlying_user_arn else "",
-            f"Using account ID: {config['account_id']}"
         ]
 
         message = "\n".join([ln for ln in lines if ln])

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -41,10 +41,6 @@ class AbstractEcr(ABC):
     def base_uri(self):
         pass
 
-    @abstractproperty
-    def registry_id(self):
-        pass
-
     def get_image_uri(self, *, namespace, image_id, tag):
         repository_name = _get_repository_name(namespace, image_id)
         return f"{self.base_uri}/{repository_name}:{tag}"
@@ -131,7 +127,6 @@ class AbstractEcr(ABC):
 
         try:
             self.client.put_image(
-                registryId=self.registry_id,
                 repositoryName=repository_name,
                 imageTag=new_tag,
                 imageManifest=existing_manifest
@@ -166,20 +161,13 @@ class EcrPrivate(AbstractEcr):
     def base_uri(self):
         return f"{self.account_id}.dkr.ecr.{self.region_name}.amazonaws.com"
 
-    @property
-    def registry_id(self):
-        return self.account_id
-
     def get_authorization_data(self):
-        resp = self.client.get_authorization_token(
-            registryIds=[self.account_id]
-        )
+        resp = self.client.get_authorization_token()
         assert len(resp["authorizationData"]) == 1
         return resp["authorizationData"][0]
 
     def get_image_manifests_for_tag(self, *, repository_name, image_tag):
         resp = self.client.batch_get_image(
-            registryId=self.registry_id,
             repositoryName=repository_name,
             imageIds=[{"imageTag": image_tag}]
         )
@@ -259,7 +247,7 @@ class NoRefTagError(EcrError):
     pass
 
 
-def get_ref_tags_for_image(ecr_client, *, repository_name, tag, account_id):
+def get_ref_tags_for_image(ecr_client, *, repository_name, tag):
     """
     Returns the ref tags for the image with this tag.
 
@@ -268,7 +256,6 @@ def get_ref_tags_for_image(ecr_client, *, repository_name, tag, account_id):
     """
     try:
         resp = ecr_client.describe_images(
-            registryId=account_id,
             repositoryName=repository_name,
             imageIds=[{"imageTag": tag}],
         )
@@ -313,7 +300,6 @@ def get_ref_tags_for_repositories(*, image_repositories, tag):
     result = {}
 
     for repo_id, repo_details in image_repositories.items():
-        account_id = repo_details["account_id"]
         region_name = repo_details["region_name"]
         role_arn = repo_details["role_arn"]
         namespace = repo_details.get("namespace", None)
@@ -327,10 +313,7 @@ def get_ref_tags_for_repositories(*, image_repositories, tag):
 
         try:
             ref_uri = get_ref_tags_for_image(
-                ecr_client,
-                repository_name=repository_name,
-                tag=tag,
-                account_id=account_id
+                ecr_client, repository_name=repository_name, tag=tag
             )
         except NoSuchImageError:
             result[repo_id] = set()

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 import base64
 import json
 import os
@@ -160,7 +160,7 @@ class EcrPrivate(AbstractEcr):
     @property
     def base_uri(self):
         account_id = iam.get_account_id(self.role_arn)
-        return f"{self.account_id}.dkr.ecr.{self.region_name}.amazonaws.com"
+        return f"{account_id}.dkr.ecr.{self.region_name}.amazonaws.com"
 
     def get_authorization_data(self):
         resp = self.client.get_authorization_token()

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -146,11 +146,11 @@ class AbstractEcr(ABC):
 
 
 class EcrPrivate(AbstractEcr):
-    def __init__(self, *, account_id, region_name, role_arn):
+    def __init__(self, *, region_name, role_arn):
         super().__init__()
 
         self.region_name = region_name
-        self.account_id = account_id
+        self.role_arn = role_arn
         self.client = create_client(
             resource="ecr",
             region_name=region_name,
@@ -159,6 +159,7 @@ class EcrPrivate(AbstractEcr):
 
     @property
     def base_uri(self):
+        account_id = iam.get_account_id(self.role_arn)
         return f"{self.account_id}.dkr.ecr.{self.region_name}.amazonaws.com"
 
     def get_authorization_data(self):
@@ -208,9 +209,8 @@ class EcrPublic(AbstractEcr):
 
 
 class Ecr:
-    def __init__(self, account_id, region_name, role_arn):
+    def __init__(self, *, region_name, role_arn):
         self._underlying = EcrPrivate(
-            account_id=account_id,
             region_name=region_name,
             role_arn=role_arn
         )
@@ -288,7 +288,6 @@ def get_ref_tags_for_repositories(*, image_repositories, tag):
     Repositories should be a dict of the form:
 
         (id) -> {
-            "account_id": (account_id),
             "region_name": (region_name),
             "role_arn": (role_arn),
             "namespace": (namespace) or None,

--- a/src/deploy/models.py
+++ b/src/deploy/models.py
@@ -37,7 +37,6 @@ class Project:
     name = attr.ib()
     role_arn = attr.ib()
 
-    account_id = attr.ib(default=None, type=str)
     aws_region_name = attr.ib(default="eu-west-1")
 
 

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -20,8 +20,7 @@ class TestGetRefTagsForImage:
             ecr.get_ref_tags_for_image(
                 ecr_client,
                 repository_name="empty_repository",
-                tag="latest",
-                account_id="1234567890",
+                tag="latest"
             )
 
     def test_get_ref_tags_for_image(self, ecr_client, region_name):
@@ -32,19 +31,16 @@ class TestGetRefTagsForImage:
 
         ecr_client.create_repository(repositoryName="example_worker")
         ecr_client.put_image(
-            registryId="1234567890",
             repositoryName="example_worker",
             imageManifest=json.dumps(manifest),
             imageTag="latest",
         )
         ecr_client.put_image(
-            registryId="1234567890",
             repositoryName="example_worker",
             imageManifest=json.dumps(manifest),
             imageTag="ref.123",
         )
         ecr_client.put_image(
-            registryId="1234567890",
             repositoryName="example_worker",
             imageManifest=json.dumps(manifest),
             imageTag="ref.456",
@@ -53,8 +49,7 @@ class TestGetRefTagsForImage:
         ref_tags = ecr.get_ref_tags_for_image(
             ecr_client,
             repository_name="example_worker",
-            tag="latest",
-            account_id="1234567890",
+            tag="latest"
         )
 
         assert ref_tags == {"ref.123", "ref.456"}
@@ -64,8 +59,7 @@ class TestGetRefTagsForImage:
             ecr.get_ref_tags_for_image(
                 ecr_client,
                 repository_name="repo_which_does_not_exist",
-                tag="latest",
-                account_id="1234567890",
+                tag="latest"
             )
 
     def test_error_if_image_does_not_have_ref_tag(self, ecr_client, region_name):
@@ -74,7 +68,6 @@ class TestGetRefTagsForImage:
         """
         ecr_client.create_repository(repositoryName="example_worker")
         ecr_client.put_image(
-            registryId="1234567890",
             repositoryName="example_worker",
             imageManifest=json.dumps(create_image_manifest()),
             imageTag="latest",
@@ -82,10 +75,7 @@ class TestGetRefTagsForImage:
 
         with pytest.raises(ecr.NoRefTagError):
             ecr.get_ref_tags_for_image(
-                ecr_client,
-                repository_name="example_worker",
-                tag="latest",
-                account_id="1234567890",
+                ecr_client, repository_name="example_worker", tag="latest"
             )
 
 
@@ -95,13 +85,11 @@ def test_get_ref_tags_for_repositories(ecr_client, region_name):
     manifest1 = create_image_manifest()
     ecr_client.create_repository(repositoryName="example_worker1")
     ecr_client.put_image(
-        registryId="1111111111",
         repositoryName="example_worker1",
         imageManifest=json.dumps(manifest1),
         imageTag="latest",
     )
     ecr_client.put_image(
-        registryId="1111111111",
         repositoryName="example_worker1",
         imageManifest=json.dumps(manifest1),
         imageTag="ref.111",
@@ -110,13 +98,11 @@ def test_get_ref_tags_for_repositories(ecr_client, region_name):
     manifest2 = create_image_manifest()
     ecr_client.create_repository(repositoryName="example_worker2")
     ecr_client.put_image(
-        registryId="2222222222",
         repositoryName="example_worker2",
         imageManifest=json.dumps(manifest2),
         imageTag="latest",
     )
     ecr_client.put_image(
-        registryId="2222222222",
         repositoryName="example_worker2",
         imageManifest=json.dumps(manifest2),
         imageTag="ref.222",
@@ -126,17 +112,14 @@ def test_get_ref_tags_for_repositories(ecr_client, region_name):
 
     image_repositories = {
         "example_worker1": {
-            "account_id": "1111111111",
             "region_name": region_name,
             "role_arn": "arn:aws:iam::1111111111:role/example-role",
         },
         "example_worker2": {
-            "account_id": "2222222222",
             "region_name": region_name,
             "role_arn": "arn:aws:iam::2222222222:role/example-role",
         },
         "example_worker3": {
-            "account_id": "3333333333",
             "region_name": region_name,
             "role_arn": "arn:aws:iam::3333333333:role/example-role",
         },

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,7 +15,6 @@ calm_adapter:
     - id: calm_deletion_checker
   name: Calm Adapter
   role_arn: arn:aws:iam::123456789012:role/platform-ci
-  account_id: 123456789012
   aws_region_name: us-east-1
 
 sierra_adapter:
@@ -46,7 +45,6 @@ def test_from_path(tmpdir):
         ],
         name="Calm Adapter",
         role_arn="arn:aws:iam::123456789012:role/platform-ci",
-        account_id="123456789012",
         aws_region_name="us-east-1",
     )
 
@@ -67,8 +65,7 @@ def test_from_path(tmpdir):
         ],
         name="Sierra Adapter",
         role_arn="arn:aws:iam::760097843905:role/platform-ci",
-        # These are the default values
-        account_id=None,
+        # Default value
         aws_region_name="eu-west-1",
     )
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -265,78 +265,6 @@ class TestPrepareConfig:
 
         prepare_config(config)
 
-    def test_uses_config_account_id(self):
-        config = {
-            "role_arn": "arn:aws:iam::1234567890:role/example-role",
-            "account_id": "1234567890"
-        }
-
-        prepare_config(config)
-        assert config["account_id"] == "1234567890"
-
-    def test_allows_overriding_account_id(self):
-        """
-        If there is no account_id in the initial config, but an override account_id
-        is supplied, that account_id is added to the config.
-        """
-        config = {"role_arn": "arn:aws:iam::1234567890:role/example-role"}
-        prepare_config(config, account_id="1234567890")
-        assert config["account_id"] == "1234567890"
-
-    def test_warns_if_account_id_conflict(self):
-        """
-        If there is an account_id in the initial config, and a different override
-        is supplied, then a warning is shown.
-        """
-        config = {
-            "role_arn": "arn:aws:iam::1234567890:role/example-role",
-            "account_id": "1111111111"
-        }
-        with pytest.warns(UserWarning, match="Preferring override account_id"):
-            prepare_config(config, account_id="1234567890")
-
-        assert config["account_id"] == "1234567890"
-
-    def test_does_not_warn_if_account_id_match(self):
-        """
-        If there is an account_id in the initial config, and it matches the override,
-        then no warning is shown.
-        """
-        config = {
-            "role_arn": "arn:aws:iam::1234567890:role/example-role",
-            "account_id": "1234567890"
-        }
-
-        with pytest.warns(None) as record:
-            prepare_config(config, account_id="1234567890")
-
-        assert len(record) == 0
-
-    def test_warns_if_account_if_does_not_match_role_arn(self):
-        """
-        If the account_id does not match the role ARN, then a warning is shown.
-        """
-        config = {
-            "role_arn": "arn:aws:iam::1234567890:role/example-role",
-            "account_id": "1111111111"
-        }
-        with pytest.warns(
-            UserWarning,
-            match="Account ID 1111111111 does not match the role"
-        ):
-            prepare_config(config)
-
-    def test_uses_account_id_from_role_if_none_specified(self):
-        """
-        If the account_id is not explicitly specified, the one in the role ARN is used.
-        """
-        config = {
-            "role_arn": "arn:aws:iam::1234567890:role/example-role",
-        }
-        prepare_config(config)
-
-        assert config["account_id"] == "1234567890"
-
 
 class TestProject:
     def test_image_repositories(self, role_arn, project_id):
@@ -345,7 +273,6 @@ class TestProject:
                 {
                     "id": "repo1",
                     "services": ["service1a", "service1b"],
-                    "account_id": "1111111111",
                     "region_name": "us-east-1",
                     "namespace": "org.wellcome",
                     "role_arn": "arn:aws:iam::1111111111:role/publisher-role"
@@ -360,7 +287,6 @@ class TestProject:
                 }
             ],
             "role_arn": role_arn,
-            "account_id": "1234567890",
             "namespace": "edu.self",
             "region_name": "eu-west-1",
         }
@@ -375,21 +301,18 @@ class TestProject:
             "repo1": {
                 "namespace": "org.wellcome",
                 "services": ["service1a", "service1b"],
-                "account_id": "1111111111",
                 "region_name": "us-east-1",
                 "role_arn": "arn:aws:iam::1111111111:role/publisher-role",
             },
             "repo2": {
                 "namespace": "edu.self",
                 "services": ["service2a", "service2b", "service2c"],
-                "account_id": "1234567890",
                 "region_name": "eu-west-1",
                 "role_arn": role_arn,
             },
             "repo3": {
                 "namespace": "edu.self",
                 "services": ["service3a"],
-                "account_id": "1234567890",
                 "region_name": "eu-west-1",
                 "role_arn": role_arn,
             },
@@ -402,7 +325,6 @@ class TestProject:
                 {"id": "prod", "name": "Prod"},
             ],
             "role_arn": role_arn,
-            "account_id": "1234567890",
             "namespace": "edu.self",
             "region_name": "eu-west-1",
         }
@@ -450,7 +372,6 @@ class TestProject:
                 {
                     "id": "repo1",
                     "services": ["service1"],
-                    "account_id": "1111111111",
                     "region_name": "us-east-1",
                     "namespace": "org.wellcome",
                     "role_arn": "arn:aws:iam::1111111111:role/publisher-role"
@@ -461,7 +382,6 @@ class TestProject:
                 {"id": "prod", "name": "Prod"},
             ],
             "role_arn": role_arn,
-            "account_id": "1234567890",
             "namespace": "edu.self",
             "region_name": "eu-west-1",
         }


### PR DESCRIPTION
Continuing to tug on the thread of https://github.com/wellcomecollection/platform/issues/5112

I had a test that was behaving oddly with different account IDs, and it made me wonder "do we care about using different account IDs with the same role ARN?". (Spoiler: no.)

We use the "account ID" parameter for two things:

1. To tell the ECR SDK which ECR registry we want to run queries/commands against
2. To construct the private ECR repository URI (`"{account_id}.dkr.ecr.{region_name}.amazonaws.com"`)

But in both cases, we don't need it to be explicitly set in `.wellcome_project`:

1. If you don't supply a registryId parameter, ECR assumes you mean the default registry. We only use the default registry, so having code to allow overrides is unnecessary.
2. You can infer the account from the role ARN, and that's what we do in most cases (`arn:aws:iam::{account_id}:role/{name}`).

Given that we never set the account ID to an "interesting" value in practice, I've removed it and all the code that surrounds it. Another 150 lines of code: 🔥🔥🔥 

---

https://github.com/wellcomecollection/catalogue/blob/master/.wellcome_project
https://github.com/wellcomecollection/stacks-service/blob/main/.wellcome_project
https://github.com/wellcomecollection/storage-service/blob/master/.wellcome_project
https://github.com/wellcomecollection/wellcomecollection.org/blob/master/.wellcome_project