### PR TITLE
Remove the namespace overrides, which we never use

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Simplify the code slightly by removing namespace overrides, which we never use in practice.  We always use the default namespace ``uk.ac.wellcome``.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -26,11 +26,10 @@ LOGGING_ROOT = os.path.join(os.environ["HOME"], ".local", "share", "weco-deploy"
 @click.option('--confirm', '-y', is_flag=True, help="Non-interactive deployment confirmation")
 @click.option("--project-id", '-i', help="Specify the project ID")
 @click.option("--region-name", '-i', help="Specify the AWS region name")
-@click.option("--namespace", help="Specify the project namespace")
 @click.option("--role-arn", help="Specify an AWS role to assume")
 @click.option('--dry-run', '-d', is_flag=True, help="Don't make changes.")
 @click.pass_context
-def cli(ctx, project_file, verbose, confirm, project_id, region_name, namespace, role_arn, dry_run):
+def cli(ctx, project_file, verbose, confirm, project_id, region_name, role_arn, dry_run):
     warn_if_not_latest_version()
 
     try:
@@ -61,8 +60,7 @@ def cli(ctx, project_file, verbose, confirm, project_id, region_name, namespace,
     project = projects.load(
         project_id=project_id,
         region_name=region_name,
-        role_arn=role_arn,
-        namespace=namespace
+        role_arn=role_arn
     )
 
     config = project.config

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -83,32 +83,38 @@ class TestGetRefTagsForImage:
 @moto.mock_iam()
 def test_get_ref_tags_for_repositories(ecr_client, region_name):
     manifest1 = create_image_manifest()
-    ecr_client.create_repository(repositoryName="example_worker1")
+    ecr_client.create_repository(
+        repositoryName="uk.ac.wellcome/example_worker1"
+    )
     ecr_client.put_image(
-        repositoryName="example_worker1",
+        repositoryName="uk.ac.wellcome/example_worker1",
         imageManifest=json.dumps(manifest1),
         imageTag="latest",
     )
     ecr_client.put_image(
-        repositoryName="example_worker1",
+        repositoryName="uk.ac.wellcome/example_worker1",
         imageManifest=json.dumps(manifest1),
         imageTag="ref.111",
     )
 
     manifest2 = create_image_manifest()
-    ecr_client.create_repository(repositoryName="example_worker2")
+    ecr_client.create_repository(
+        repositoryName="uk.ac.wellcome/example_worker2"
+    )
     ecr_client.put_image(
-        repositoryName="example_worker2",
+        repositoryName="uk.ac.wellcome/example_worker2",
         imageManifest=json.dumps(manifest2),
         imageTag="latest",
     )
     ecr_client.put_image(
-        repositoryName="example_worker2",
+        repositoryName="uk.ac.wellcome/example_worker2",
         imageManifest=json.dumps(manifest2),
         imageTag="ref.222",
     )
 
-    ecr_client.create_repository(repositoryName="example_worker3")
+    ecr_client.create_repository(
+        repositoryName="uk.ac.wellcome/example_worker3"
+    )
 
     image_repositories = {
         "example_worker1": {

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -20,55 +20,6 @@ def test_loading_non_existent_project_is_runtimeerror(tmpdir):
 
 
 class TestPrepareConfig:
-    def test_uses_config_namespace(self, role_arn):
-        """
-        ProjectConfig uses the namespace in the initial config.
-        """
-        config = {"namespace": "edu.self", "role_arn": role_arn}
-        prepare_config(config)
-        assert config["namespace"] == "edu.self"
-
-    def test_allows_overriding_namespace(self, role_arn):
-        """
-        If there is no namespace in the initial config, but an override namespace
-        is supplied, that namespace is added to the config.
-        """
-        config = {"role_arn": role_arn}
-        prepare_config(config, namespace="edu.self")
-        assert config["namespace"] == "edu.self"
-
-    def test_uses_default_namespace(self, role_arn):
-        """
-        If there is no namespace in the initial config, and no override is supplied,
-        then the default namespace is added to the config.
-        """
-        config = {"role_arn": role_arn}
-        prepare_config(config)
-        assert config["namespace"] == "uk.ac.wellcome"
-
-    def test_warns_if_namespace_conflict(self, role_arn):
-        """
-        If there is a namespace in the initial config, and a different override
-        is supplied, then a warning is shown.
-        """
-        config = {"namespace": "edu.self", "role_arn": role_arn}
-        with pytest.warns(UserWarning, match="Preferring override"):
-            prepare_config(config, namespace="uk.ac.wellcome")
-
-        assert config["namespace"] == "uk.ac.wellcome"
-
-    def test_does_not_warn_if_namespace_match(self, role_arn):
-        """
-        If there is a namespace in the initial config, and it matches the override,
-        then no warning is shown.
-        """
-        config = {"namespace": "edu.self", "role_arn": role_arn}
-
-        with pytest.warns(None) as record:
-            prepare_config(config, namespace="edu.self")
-
-        assert len(record) == 0
-
     def test_allows_overriding_role_arn(self, role_arn):
         """
         If there is no role_arn in the initial config, but an override role_arn
@@ -274,7 +225,6 @@ class TestProject:
                     "id": "repo1",
                     "services": ["service1a", "service1b"],
                     "region_name": "us-east-1",
-                    "namespace": "org.wellcome",
                     "role_arn": "arn:aws:iam::1111111111:role/publisher-role"
                 },
                 {
@@ -287,7 +237,6 @@ class TestProject:
                 }
             ],
             "role_arn": role_arn,
-            "namespace": "edu.self",
             "region_name": "eu-west-1",
         }
 
@@ -299,19 +248,16 @@ class TestProject:
 
         assert project.image_repositories == {
             "repo1": {
-                "namespace": "org.wellcome",
                 "services": ["service1a", "service1b"],
                 "region_name": "us-east-1",
                 "role_arn": "arn:aws:iam::1111111111:role/publisher-role",
             },
             "repo2": {
-                "namespace": "edu.self",
                 "services": ["service2a", "service2b", "service2c"],
                 "region_name": "eu-west-1",
                 "role_arn": role_arn,
             },
             "repo3": {
-                "namespace": "edu.self",
                 "services": ["service3a"],
                 "region_name": "eu-west-1",
                 "role_arn": role_arn,
@@ -325,7 +271,6 @@ class TestProject:
                 {"id": "prod", "name": "Prod"},
             ],
             "role_arn": role_arn,
-            "namespace": "edu.self",
             "region_name": "eu-west-1",
         }
 
@@ -373,7 +318,6 @@ class TestProject:
                     "id": "repo1",
                     "services": ["service1"],
                     "region_name": "us-east-1",
-                    "namespace": "org.wellcome",
                     "role_arn": "arn:aws:iam::1111111111:role/publisher-role"
                 },
             ],
@@ -382,7 +326,6 @@ class TestProject:
                 {"id": "prod", "name": "Prod"},
             ],
             "role_arn": role_arn,
-            "namespace": "edu.self",
             "region_name": "eu-west-1",
         }
 


### PR DESCRIPTION
Continuing to tug on the thread of wellcomecollection/platform#5112

We always use the default namespace `uk.ac.wellcome`, or overriding it at about three different levels in the config. I've removed all the namespace-handling code for now as unnecessary flexibility, but it should be easier to restore later once we have the config defined as easy-to-understand models (https://github.com/wellcomecollection/weco-deploy/pull/98).