### PR TITLE
Start to use the new models internally; remove duplicated config parsing code

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This does some refactoring to use our new models for config parsing and validation.  There should be no user-visible effect.

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -276,32 +276,19 @@ def get_ref_tags_for_image(ecr_client, *, repository_name, tag):
     return ref_tags
 
 
-def get_ref_tags_for_repositories(*, image_repositories, tag):
+def get_ref_tags_for_repositories(ecr_client, *, image_repositories, tag):
     """
     Returns the ref tags for all the repositories in ``image_repositories``.
 
-    Repositories should be a dict of the form:
-
-        (id) -> {
-            "region_name": (region_name),
-            "role_arn": (role_arn),
-        }
+    The ``image_repositories`` should be a list of repo IDs.
 
     Returns a dict (id) -> set(ref_tags)
 
     """
     result = {}
 
-    for repo_id, repo_details in image_repositories.items():
-        region_name = repo_details["region_name"]
-        role_arn = repo_details["role_arn"]
+    for repo_id in image_repositories:
         repository_name = _get_repository_name(repo_id)
-
-        ecr_client = create_client(
-            resource="ecr",
-            region_name=region_name,
-            role_arn=role_arn
-        )
 
         try:
             ref_uri = get_ref_tags_for_image(

--- a/src/deploy/models.py
+++ b/src/deploy/models.py
@@ -28,14 +28,15 @@ class ImageRepository:
 
 @attr.s
 class Project:
-    environments: typing.List[Environment] = attr.ib(
-        converter=convert_identified_list_to_dict
-    )
-    image_repositories: typing.List[ImageRepository] = attr.ib(
-        converter=convert_identified_list_to_dict
-    )
     name = attr.ib()
     role_arn = attr.ib()
+
+    environments: typing.List[Environment] = attr.ib(
+        factory=list, converter=convert_identified_list_to_dict
+    )
+    image_repositories: typing.List[ImageRepository] = attr.ib(
+        factory=list, converter=convert_identified_list_to_dict
+    )
 
     aws_region_name = attr.ib(default="eu-west-1")
 

--- a/src/deploy/models.py
+++ b/src/deploy/models.py
@@ -40,6 +40,10 @@ class Project:
 
     aws_region_name = attr.ib(default="eu-west-1")
 
+    @property
+    def region_name(self):
+        return self.aws_region_name
+
 
 class ProjectList:
     @classmethod

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -227,7 +227,7 @@ class Project:
             )
 
             return {
-                'config': service,
+                'config': {"id": service_id},
                 'response': ecs_service
             }
 

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -176,8 +176,6 @@ class Project:
 
         Every repository will have the following keys:
 
-        -   region_name
-        -   role_arn
         -   services
 
         """
@@ -189,8 +187,6 @@ class Project:
             assert repo["id"] not in result, repo["id"]
 
             result[repo["id"]] = {
-                "region_name": repo.get("region_name", self.region_name),
-                "role_arn": repo.get("role_arn", self.role_arn),
                 "services": repo.get("services", []),
             }
 
@@ -415,7 +411,11 @@ class Project:
         is chosen arbitrarily.
         """
         ref_tags_resp = ecr.get_ref_tags_for_repositories(
-            image_repositories=self.image_repositories,
+            self.ecr._underlying.client,
+            image_repositories=[
+                repo["id"]
+                for repo in self.config.get("image_repositories", [])
+            ],
             tag=from_label
         )
 

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -342,10 +342,7 @@ class Project:
         """
         ref_tags_resp = ecr.get_ref_tags_for_repositories(
             self.ecr._underlying.client,
-            image_repositories=[
-                repo["id"]
-                for repo in self.config.get("image_repositories", [])
-            ],
+            image_repositories=self.image_repositories.keys(),
             tag=from_label
         )
 

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -95,6 +95,9 @@ class Project:
         self.id = project_id
         self._underlying = cattr.structure(config, models.Project)
 
+        self.config = config
+        self.config["id"] = project_id
+
         self.release_store = release_store
         self.release_store.initialise()
 

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -4,9 +4,10 @@ import functools
 import uuid
 import warnings
 
+import cattr
 import yaml
 
-from . import ecr, iam
+from . import ecr, iam, models
 from .ecr import Ecr
 from .ecs import Ecs
 from .exceptions import ConfigError
@@ -139,6 +140,8 @@ class Project:
 
         self.release_store = release_store
         self.release_store.initialise()
+
+        self._underlying = cattr.structure(config, models.Project)
 
     @property
     @functools.lru_cache()

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -92,14 +92,11 @@ def prepare_config(
 
 class Project:
     def __init__(self, project_id, config, release_store):
-        self.config = config
-
-        self.config["id"] = project_id
+        self.id = project_id
+        self._underlying = cattr.structure(config, models.Project)
 
         self.release_store = release_store
         self.release_store.initialise()
-
-        self._underlying = cattr.structure(config, models.Project)
 
     @property
     @functools.lru_cache()
@@ -117,10 +114,6 @@ class Project:
     @functools.lru_cache()
     def ecr(self):
         return Ecr(region_name=self.region_name, role_arn=self.role_arn)
-
-    @property
-    def id(self):
-        return self.config["id"]
 
     @property
     def role_arn(self):
@@ -153,7 +146,7 @@ class Project:
         return {
             "release_id": release_id,
             "project_id": self.id,
-            "project_name": self.config.get('name', 'unnamed'),
+            "project_name": self._underlying.name,
             "date_created": datetime.datetime.utcnow().isoformat(),
             "requested_by": iam.get_underlying_role_arn(),
             "description": description,

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -24,11 +24,11 @@ def wellcome_project_file(tmpdir, project_id, role_arn):
               image_repositories:
                 - id: repo1
                   services:
-                  - service1a
-                  - service1b
+                  - id: service1a
+                  - id: service1b
                 - id: repo2
                   services:
-                  - service2a
+                  - id: service2a
               name: My project
               role_arn: {role_arn}
             """))

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -132,6 +132,7 @@ def test_get_ref_tags_for_repositories(ecr_client, region_name):
     }
 
     uris = ecr.get_ref_tags_for_repositories(
+        ecr_client,
         image_repositories=image_repositories,
         tag="latest"
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -115,7 +115,7 @@ def test_duplicate_ids(bad_yaml):
 
 
 def test_image_repositories_default_is_empty():
-    yaml =     """
+    yaml = """
     example_project:
       environments:
         - id: prod
@@ -130,7 +130,7 @@ def test_image_repositories_default_is_empty():
 
 
 def test_environments_default_is_empty():
-    yaml =     """
+    yaml = """
     example_project:
       image_repositories:
         - id: example_project

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -112,3 +112,30 @@ def test_from_path(tmpdir):
 def test_duplicate_ids(bad_yaml):
     with pytest.raises(ConfigError, match="Duplicate IDs:"):
         ProjectList.from_text(bad_yaml)
+
+
+def test_image_repositories_default_is_empty():
+    yaml =     """
+    example_project:
+      environments:
+        - id: prod
+          name: Production
+        - id: staging
+          name: Staging
+      name: Example Project
+      role_arn: arn:aws:iam::123456789012:role/example-ci
+    """
+    p = ProjectList.from_text(yaml)
+    assert p["example_project"].image_repositories == {}
+
+
+def test_environments_default_is_empty():
+    yaml =     """
+    example_project:
+      image_repositories:
+        - id: example_project
+      name: Example Project
+      role_arn: arn:aws:iam::123456789012:role/example-ci
+    """
+    p = ProjectList.from_text(yaml)
+    assert p["example_project"].environments == {}

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -223,21 +223,26 @@ class TestProject:
             "image_repositories": [
                 {
                     "id": "repo1",
-                    "services": ["service1a", "service1b"],
+                    "services": [{"id": "service1a"}, {"id": "service1b"}],
                     "region_name": "us-east-1",
                     "role_arn": "arn:aws:iam::1111111111:role/publisher-role"
                 },
                 {
                     "id": "repo2",
-                    "services": ["service2a", "service2b", "service2c"]
+                    "services": [
+                        {"id": "service2a"},
+                        {"id": "service2b"},
+                        {"id": "service2c"},
+                    ]
                 },
                 {
                     "id": "repo3",
-                    "services": ["service3a"]
+                    "services": [{"id": "service3a"}]
                 }
             ],
             "role_arn": role_arn,
             "region_name": "eu-west-1",
+            "name": "Example Project",
         }
 
         project = Project(
@@ -248,19 +253,17 @@ class TestProject:
 
         assert project.image_repositories == {
             "repo1": {
-                "services": ["service1a", "service1b"],
-                "region_name": "us-east-1",
-                "role_arn": "arn:aws:iam::1111111111:role/publisher-role",
+                "services": [{"id": "service1a"}, {"id": "service1b"}],
             },
             "repo2": {
-                "services": ["service2a", "service2b", "service2c"],
-                "region_name": "eu-west-1",
-                "role_arn": role_arn,
+                "services": [
+                    {"id": "service2a"},
+                    {"id": "service2b"},
+                    {"id": "service2c"},
+                ],
             },
             "repo3": {
-                "services": ["service3a"],
-                "region_name": "eu-west-1",
-                "role_arn": role_arn,
+                "services": [{"id": "service3a"}],
             },
         }
 
@@ -272,6 +275,7 @@ class TestProject:
             ],
             "role_arn": role_arn,
             "region_name": "eu-west-1",
+            "name": "Example Project",
         }
 
         project = Project(
@@ -300,7 +304,10 @@ class TestProject:
 
         project = Project(
             project_id=project_id,
-            config={"role_arn": role_arn},
+            config={
+                "role_arn": role_arn,
+                "name": "Example Project",
+            },
             release_store=release_store
         )
 
@@ -316,7 +323,7 @@ class TestProject:
             "image_repositories": [
                 {
                     "id": "repo1",
-                    "services": ["service1"],
+                    "services": [{"id": "service1"}],
                     "region_name": "us-east-1",
                     "role_arn": "arn:aws:iam::1111111111:role/publisher-role"
                 },
@@ -327,6 +334,7 @@ class TestProject:
             ],
             "role_arn": role_arn,
             "region_name": "eu-west-1",
+            "name": "Example Project",
         }
 
         project = Project(


### PR DESCRIPTION
This patch starts to bring in the models from https://github.com/wellcomecollection/weco-deploy/pull/98, part of https://github.com/wellcomecollection/platform/issues/5112

I started from the `get_ref_tags_for_repositories` method, and worked my way upwards. The old `Project` class is wrapping an instance of the new `Project` model in the _underlying attribute. I'll gradually refactor outwards to ditch that _underlying, but this is good enough as a next step.