### PR TITLE
Start breaking up the old Project class

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+More internal refactoring that should have no user-visible effect.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -9,7 +9,7 @@ from dateutil.parser import parse
 from pprint import pprint
 from tabulate import tabulate
 
-from . import git, iam
+from . import ecs, git, iam
 from .pretty_printing import pprint_date
 from .project import Projects
 from .version_check import warn_if_not_latest_version, current_version
@@ -154,8 +154,10 @@ def _deploy(project, release, environment_id, description, confirm=True):
     click.echo(click.style(f"Requested by: {release['requested_by']}", fg="yellow"))
     click.echo(click.style(f"Date created: {release['date_created']}", fg="yellow"))
 
-    ecs_service_arns = project.get_ecs_service_arns(
+    ecs_service_arns = ecs.find_service_arns_for_release(
+        project=project._underlying,
         release=release,
+        service_descriptions=project.ecs._described_services,
         environment_id=environment_id
     )
 

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -135,13 +135,6 @@ class Ecs:
             'deployment_id': response['service']['deployments'][0]['id']
         }
 
-    def find_matching_service(self, **kwargs):
-        """
-        Given a service (e.g. bag-unpacker) and an environment (e.g. prod),
-        return the unique matching service.
-        """
-        return find_matching_service(self._described_services, **kwargs)
-
     def list_service_tasks(self, service):
         """
         Given a service (e.g. bag-unpacker),

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -181,17 +181,6 @@ class Project:
         else:
             return self.release_store.get_release(release_id)
 
-    def get_ecs_service_arns(self, release, environment_id):
-        """
-        Returns a dict (image ID) -> List[service ARNs].
-        """
-        return find_service_arns_for_release(
-            project=self._underlying,
-            release=release,
-            service_descriptions=self.ecs._described_services,
-            environment_id=environment_id
-        )
-
     def get_ecs_services(self, release, environment_id, cached=True):
         def _get_service(service_id):
             # Sometimes we want not to use the service cache - eg when checking

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -8,7 +8,7 @@ import yaml
 
 from . import ecr, iam, models
 from .ecr import Ecr
-from .ecs import Ecs, find_matching_service, find_service_arns_for_release
+from .ecs import Ecs, find_matching_service
 from .exceptions import ConfigError
 from .release_store import DynamoReleaseStore, ReleaseNotFoundError
 from .tags import parse_aws_tags

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -8,7 +8,7 @@ import yaml
 
 from . import ecr, iam, models
 from .ecr import Ecr
-from .ecs import Ecs, find_service_arns_for_release
+from .ecs import Ecs, find_matching_service, find_service_arns_for_release
 from .exceptions import ConfigError
 from .release_store import DynamoReleaseStore, ReleaseNotFoundError
 from .tags import parse_aws_tags
@@ -191,7 +191,8 @@ class Project:
             else:
                 ecs = self.ecs
 
-            ecs_service = ecs.find_matching_service(
+            ecs_service = find_matching_service(
+                service_descriptions=ecs._described_services,
                 service_id=service_id,
                 environment_id=environment_id
             )

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -1,4 +1,3 @@
-import collections
 import datetime
 import functools
 import uuid
@@ -9,7 +8,7 @@ import yaml
 
 from . import ecr, iam, models
 from .ecr import Ecr
-from .ecs import Ecs
+from .ecs import Ecs, find_service_arns_for_release
 from .exceptions import ConfigError
 from .release_store import DynamoReleaseStore, ReleaseNotFoundError
 from .tags import parse_aws_tags
@@ -182,37 +181,16 @@ class Project:
         else:
             return self.release_store.get_release(release_id)
 
-    def _get_services_by_image_id(self, release):
-        """
-        Generates a set of tuples (image_id, List[services])
-        """
-        for image_id in release["images"]:
-            try:
-                matched_image = self.image_repositories[image_id]
-            except KeyError:
-                continue
-
-            yield (image_id, matched_image["services"])
-
     def get_ecs_service_arns(self, release, environment_id):
         """
         Returns a dict (image ID) -> List[service ARNs].
         """
-        result = collections.defaultdict(list)
-
-        for image_id, services in self._get_services_by_image_id(release):
-            for service_id in services:
-                matching_service = self.ecs.find_matching_service(
-                    service_id=service_id,
-                    environment_id=environment_id
-                )
-
-                try:
-                    result[image_id].append(matching_service["serviceArn"])
-                except TypeError:
-                    assert matching_service is None, matching_service
-
-        return dict(result)
+        return find_service_arns_for_release(
+            project=self._underlying,
+            release=release,
+            service_descriptions=self.ecs._described_services,
+            environment_id=environment_id
+        )
 
     def get_ecs_services(self, release, environment_id, cached=True):
         def _get_service(service_id):

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -3,9 +3,13 @@ import pytest
 from deploy.ecs import (
     describe_services,
     find_matching_service,
+    find_service_arns_for_release,
     list_cluster_arns_in_account,
-    list_service_arns_in_cluster
+    list_service_arns_in_cluster,
+    MultipleMatchingServicesError,
+    NoMatchingServiceError,
 )
+from deploy.models import ImageRepository, Project, Service
 
 
 @pytest.fixture(scope="session")
@@ -65,7 +69,7 @@ def test_describe_services(ecs_client, ecs_stack):
 
 def test_find_matching_service(ecs_client, ecs_stack):
     service_1a = {
-        "serviceArn": "serviceArn': 'arn:aws:ecs:eu-west-1:012345678910:service/service1a",
+        "serviceArn": "arn:aws:ecs:eu-west-1:012345678910:service/service1a",
         "tags": [
             {
                 "key": "deployment:service",
@@ -79,7 +83,7 @@ def test_find_matching_service(ecs_client, ecs_stack):
     }
 
     service_1b = {
-        "serviceArn": "serviceArn': 'arn:aws:ecs:eu-west-1:012345678910:service/service1b",
+        "serviceArn": "arn:aws:ecs:eu-west-1:012345678910:service/service1b",
         "tags": [
             {
                 "key": "deployment:service",
@@ -93,7 +97,7 @@ def test_find_matching_service(ecs_client, ecs_stack):
     }
 
     service_1c = {
-        "serviceArn": "serviceArn': 'arn:aws:ecs:eu-west-1:012345678910:service/service1c",
+        "serviceArn": "arn:aws:ecs:eu-west-1:012345678910:service/service1c",
         "tags": [
             {
                 "key": "deployment:service",
@@ -114,15 +118,96 @@ def test_find_matching_service(ecs_client, ecs_stack):
         environment_id="prod"
     ) == service_1a
 
-    assert find_matching_service(
-        service_descriptions,
-        service_id="service2",
-        environment_id="prod"
-    ) is None
+    with pytest.raises(NoMatchingServiceError):
+        assert find_matching_service(
+            service_descriptions,
+            service_id="service2",
+            environment_id="prod"
+        )
 
-    with pytest.raises(RuntimeError, match="Multiple matching services found"):
+    with pytest.raises(MultipleMatchingServicesError):
         find_matching_service(
             service_descriptions,
             service_id="service1",
             environment_id="staging"
         )
+
+
+def test_find_service_arns_for_release(ecs_client, ecs_stack):
+    service_1a = {
+        "serviceArn": "arn:aws:ecs:eu-west-1:012345678910:service/service1a",
+        "tags": [
+            {
+                "key": "deployment:service",
+                "value": "service1",
+            },
+            {
+                "key": "deployment:env",
+                "value": "prod",
+            },
+        ]
+    }
+
+    service_1b = {
+        "serviceArn": "arn:aws:ecs:eu-west-1:012345678910:service/service1b",
+        "tags": [
+            {
+                "key": "deployment:service",
+                "value": "service1",
+            },
+            {
+                "key": "deployment:env",
+                "value": "staging",
+            },
+        ]
+    }
+
+    service_1c = {
+        "serviceArn": "arn:aws:ecs:eu-west-1:012345678910:service/service2",
+        "tags": [
+            {
+                "key": "deployment:service",
+                "value": "service2",
+            },
+            {
+                "key": "deployment:env",
+                "value": "prod",
+            },
+        ]
+    }
+
+    service_descriptions = [service_1a, service_1b, service_1c]
+
+    project = Project(
+        name="Example Project",
+        role_arn="arn:aws:iam::123456789012:role/example-ci",
+        image_repositories=[
+            ImageRepository(id="repo1", services=[Service(id="service1")]),
+            ImageRepository(id="repo2", services=[Service(id="service2")])
+        ]
+    )
+
+    result = find_service_arns_for_release(
+        project=project,
+        release={"images": ["repo1", "repo2", "repo3"]},
+        service_descriptions=service_descriptions,
+        environment_id="prod"
+    )
+
+    assert result == {
+        "repo1": ["arn:aws:ecs:eu-west-1:012345678910:service/service1a"],
+        "repo2": ["arn:aws:ecs:eu-west-1:012345678910:service/service2"],
+        "repo3": []
+    }
+
+    result = find_service_arns_for_release(
+        project=project,
+        release={"images": ["repo1", "repo2"]},
+        service_descriptions=service_descriptions,
+        environment_id="staging"
+    )
+
+    assert result == {
+        "repo1": ["arn:aws:ecs:eu-west-1:012345678910:service/service1b"],
+        "repo2": [],
+    }


### PR DESCRIPTION
Continuing to refactor for https://github.com/wellcomecollection/platform/issues/5112; should be no user-visible effect.

This PR started as me asking "can I remove `get_ecs_service_arns` from the old Project class", at which point I discovered:

1. That method wasn't being tested
2. That method manipulates a few in-memory data structures, but otherwise does very little

So I pulled it out as a standalone function, added a few tests to it, and got to simplify it a bit at the same time.

The code is a bit messy right now, but I hope (🤞) that it'll be easier to work with once I'm done, and that it's heading in the right direction.