### PR TITLE
Test the remainder of ecs.py

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+More internal refactoring that should have no user-visible effect.

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -27,6 +27,8 @@ def describe_services(ecs_client):
     """
     Describe all the ECS services in an account.
     """
+    result = []
+
     for cluster in list_cluster_arns_in_account(ecs_client):
         service_arns = list_service_arns_in_cluster(ecs_client, cluster=cluster)
 
@@ -38,7 +40,9 @@ def describe_services(ecs_client):
                 include=["TAGS"]
             )
 
-            yield from resp["services"]
+            result.extend(resp["services"])
+
+    return result
 
 
 class NoMatchingServiceError(Exception):
@@ -167,4 +171,4 @@ class Ecs:
             region_name=region_name
         )
         self.ecs = self.session.client('ecs')
-        self._described_services = list(describe_services(self.ecs))
+        self._described_services = describe_services(self.ecs)

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -1,4 +1,4 @@
-from . import iam, tags
+from . import tags
 from .iterators import chunked_iterable
 from .models import Project
 
@@ -23,10 +23,11 @@ def list_service_arns_in_cluster(ecs_client, *, cluster):
         yield from page["serviceArns"]
 
 
-def describe_services(ecs_client):
+def describe_services(session):
     """
     Describe all the ECS services in an account.
     """
+    ecs_client = session.client("ecs")
     result = []
 
     for cluster in list_cluster_arns_in_account(ecs_client):
@@ -160,15 +161,3 @@ def list_tasks_in_service(session, *, cluster_arn, service_name):
         return resp["tasks"]
     else:
         return []
-
-
-
-class Ecs:
-    def __init__(self, region_name, role_arn):
-        self.session = iam.get_session(
-            session_name="ReleaseToolEcs",
-            role_arn=role_arn,
-            region_name=region_name
-        )
-        self.ecs = self.session.client('ecs')
-        self._described_services = describe_services(self.ecs)

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -175,10 +175,10 @@ class Project:
             return self.release_store.get_release(release_id)
 
     def get_ecs_services(self, release, environment_id, cached=True):
-        def _get_service(service_id):
-            # We always get a fresh set of ECS service descriptions.
-            service_descriptions = ecs.describe_services(self.session)
+        # We always get a fresh set of ECS service descriptions.
+        service_descriptions = ecs.describe_services(self.session)
 
+        def _get_service(service_id):
             ecs_service = ecs.find_matching_service(
                 service_descriptions=service_descriptions,
                 service_id=service_id,

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -174,7 +174,7 @@ class Project:
         else:
             return self.release_store.get_release(release_id)
 
-    def get_ecs_services(self, release, environment_id, cached=True):
+    def get_ecs_services(self, release, environment_id):
         # We always get a fresh set of ECS service descriptions.
         service_descriptions = ecs.describe_services(self.session)
 
@@ -214,7 +214,7 @@ class Project:
         on the tasks within those services. We check that the desiredCount
         of tasks matches the running count of tasks.
         """
-        ecs_services = self.get_ecs_services(release, environment_id, cached=False)
+        ecs_services = self.get_ecs_services(release, environment_id)
 
         def printv(str):
             if verbose:

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -246,7 +246,12 @@ class Project:
                 service_arn = service["response"]["serviceArn"]
                 service_deployment_label = service_tags["deployment:label"]
                 desired_task_count = service["response"]["desiredCount"]
-                tasks = self.ecs.list_service_tasks(service)
+
+                tasks = list_tasks_in_service(
+                    self.session,
+                    cluster_arn=service["response"]["clusterArn"],
+                    service_name=service["response"]["serviceName"],
+                )
 
                 for task in tasks:
                     task_tags = parse_aws_tags(task["tags"])

--- a/src/deploy/tags.py
+++ b/src/deploy/tags.py
@@ -22,6 +22,22 @@ def parse_aws_tags(tags):
     return result
 
 
+def to_aws_tags(tags):
+    """
+    When you assign tags to an AWS resource, you have to use the form
+
+        [{"key": "KEY1", "value": "VALUE1"},
+         {"key": "KEY2", "value": "VALUE2"},
+         ...]
+
+    This function converts a Python-style dict() into these tags.
+    """
+    return [
+        {"key": key, "value": value}
+        for key, value in tags.items()
+    ]
+
+
 class MultipleMatchingResourcesError(ValueError):
     """
     Raised if there are multiple resources matching a given set of tags.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,8 @@ def aws_credentials():
 
 
 @pytest.fixture(scope="session")
-def session(aws_credentials):
-    return boto3.Session()
+def session(aws_credentials, region_name):
+    return boto3.Session(region_name=region_name)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,11 @@ def aws_credentials():
 
 
 @pytest.fixture(scope="session")
+def session(aws_credentials):
+    return boto3.Session()
+
+
+@pytest.fixture(scope="session")
 def ecr_client(aws_credentials, region_name):
     with moto.mock_ecr():
         yield boto3.client("ecr", region_name=region_name)

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -7,11 +7,12 @@ from deploy.ecs import (
     find_service_arns_for_release,
     list_cluster_arns_in_account,
     list_service_arns_in_cluster,
+    list_tasks_in_service,
     MultipleMatchingServicesError,
     NoMatchingServiceError,
 )
 from deploy.models import ImageRepository, Project, Service
-from deploy.tags import parse_aws_tags
+from deploy.tags import parse_aws_tags, to_aws_tags
 
 
 @pytest.fixture(scope="session")
@@ -262,3 +263,20 @@ def test_deploy_service(session, ecs_stack):
     assert tags == {
         "deployment:label": "testing_again"
     }
+
+
+
+def test_list_tasks_in_service(session, ecs_stack):
+    # Annoyingly, there's no way for the StartTask API to start tasks in
+    # a named service, so we'll never find anything useful here.
+    #
+    # I'm calling the method so we get some sense checking that it's
+    # not completely broken, but it'd be nice if we could test it
+    # more thoroughly.
+
+    resp = list_tasks_in_service(
+        session,
+        cluster_arn="arn:aws:ecs:eu-west-1:012345678910:cluster/cluster1",
+        service_name="service1a"
+    )
+    assert resp == []

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -58,8 +58,8 @@ def test_list_service_arns_in_cluster(ecs_client, ecs_stack):
     ]
 
 
-def test_describe_services(ecs_client, ecs_stack):
-    service_descriptions = list(describe_services(ecs_client))
+def test_describe_services(session, ecs_stack):
+    service_descriptions = describe_services(session)
 
     assert len(service_descriptions) == 5
     assert all("tags" in desc for desc in service_descriptions)

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -12,7 +12,7 @@ from deploy.ecs import (
     NoMatchingServiceError,
 )
 from deploy.models import ImageRepository, Project, Service
-from deploy.tags import parse_aws_tags, to_aws_tags
+from deploy.tags import parse_aws_tags
 
 
 @pytest.fixture(scope="session")
@@ -263,7 +263,6 @@ def test_deploy_service(session, ecs_stack):
     assert tags == {
         "deployment:label": "testing_again"
     }
-
 
 
 def test_list_tasks_in_service(session, ecs_stack):


### PR DESCRIPTION
Continuing to tidy up the types, as per wellcomecollection/platform#5112. Follows https://github.com/wellcomecollection/weco-deploy/pull/103

We were passing around raw ECS API responses, which gets hopelessly confusing and ties the correct working of our code to an external API. Eww.

This patch breaks up the Ecs class, adds proper testing around it, and continues to simplify some of the code in `project.py`. I'll start picking bits off that class next.