### PR TITLE
Move more methods out of the old Project class

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+More internal refactoring that should have no user-visible effect.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -240,7 +240,7 @@ def deploy(ctx, release_id, environment_id, description, confirmation_wait_for, 
     project = ctx.obj['project']
     verbose = ctx.obj['verbose']
 
-    release = project.get_release(release_id)
+    release = project.release_store.get_release(release_id)
 
     _deploy(
         project=project,
@@ -464,7 +464,7 @@ def show_release(ctx, release_id):
     if not release_id:
         release_id = 'latest'
 
-    release = project.get_release(release_id)
+    release = project.release_store.get_release(release_id)
 
     click.echo(json.dumps(release, sort_keys=True, indent=2))
 
@@ -487,7 +487,7 @@ def show_deployments(ctx, release_id, environment_id, limit):
         "description"
     ]
 
-    for deployment in project.get_deployments(
+    for deployment in project.release_store.get_deployments(
         release_id=release_id,
         environment_id=environment_id,
         limit=limit

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -96,7 +96,7 @@ def cli(ctx, project_file, verbose, confirm, project_id, region_name, role_arn, 
 def _publish(project, image_id, label):
     click.echo(click.style(f"Attempting to publish {project.id}/{image_id}", fg="green"))
 
-    publish_result = project.publish(
+    publish_result = project.ecr._underlying.publish(
         image_id=image_id,
         label=label
     )

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -96,7 +96,7 @@ def cli(ctx, project_file, verbose, confirm, project_id, region_name, role_arn, 
 def _publish(project, image_id, label):
     click.echo(click.style(f"Attempting to publish {project.id}/{image_id}", fg="green"))
 
-    publish_result = project.ecr._underlying.publish(
+    publish_result = project.ecr.publish(
         image_id=image_id,
         label=label
     )

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -168,6 +168,31 @@ class AbstractEcr(ABC):
 
         return result
 
+    def publish(self, *, image_id, label):
+        """
+        Publishes an image to ECR.
+        """
+        self.login()
+
+        remote_uri, remote_tag, local_tag = self.publish_image(
+            image_id=image_id
+        )
+
+        tag_result = self.tag_image(
+            image_id=image_id,
+            tag=remote_tag,
+            new_tag=label
+        )
+
+        return {
+            "ecr_push": {
+                "local_tag": local_tag,
+                "remote_tag": remote_tag,
+                "remote_uri": remote_uri,
+            },
+            "ecr_tag": tag_result
+        }
+
 
 class EcrPrivate(AbstractEcr):
     def __init__(self, *, region_name, role_arn):

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -257,14 +257,6 @@ class EcrPublic(AbstractEcr):
         return [output]
 
 
-class Ecr:
-    def __init__(self, *, region_name, role_arn):
-        self._underlying = EcrPrivate(
-            region_name=region_name,
-            role_arn=role_arn
-        )
-
-
 class NoSuchImageError(EcrError):
     """
     Raised when an image cannot be found.

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -264,19 +264,6 @@ class Ecr:
             role_arn=role_arn
         )
 
-    def publish_image(self, image_id):
-        return self._underlying.publish_image(image_id=image_id)
-
-    def tag_image(self, image_id, tag, new_tag):
-        return self._underlying.tag_image(
-            image_id=image_id,
-            tag=tag,
-            new_tag=new_tag
-        )
-
-    def login(self):
-        self._underlying.login()
-
 
 class NoSuchImageError(EcrError):
     """

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -7,7 +7,7 @@ import cattr
 import yaml
 
 from . import ecs, ecr, iam, models
-from .ecr import Ecr
+from .ecr import EcrPrivate
 from .exceptions import ConfigError
 from .release_store import DynamoReleaseStore, ReleaseNotFoundError
 from .tags import parse_aws_tags
@@ -108,7 +108,7 @@ class Project:
     @property
     @functools.lru_cache()
     def ecr(self):
-        return Ecr(region_name=self.region_name, role_arn=self.role_arn)
+        return EcrPrivate(region_name=self.region_name, role_arn=self.role_arn)
 
     @property
     def role_arn(self):
@@ -249,7 +249,7 @@ class Project:
         Note: a single Docker image may have multiple ref tags, so the ref tag
         is chosen arbitrarily.
         """
-        ref_tags_resp = self.ecr._underlying.get_ref_tags_for_repositories(
+        ref_tags_resp = self.ecr.get_ref_tags_for_repositories(
             image_repositories=self.image_repositories.keys(),
             tag=from_label
         )

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -149,12 +149,6 @@ class Project:
             "deployments": []
         }
 
-    def get_release(self, release_id):
-        if release_id == "latest":
-            return self.release_store.get_most_recent_release()
-        else:
-            return self.release_store.get_release(release_id)
-
     def get_ecs_services(self, release, environment_id):
         # We always get a fresh set of ECS service descriptions.
         service_descriptions = ecs.describe_services(self.session)
@@ -323,7 +317,7 @@ class Project:
         )
 
     def update(self, release_id, service_ids, from_label):
-        release = self.get_release(release_id)
+        release = self.release_store.get_release(release_id)
         images = self.get_images(from_label)
 
         # Ensure all specified services are available as images
@@ -355,7 +349,7 @@ class Project:
         )
 
     def deploy(self, release_id, environment_id, description):
-        release = self.get_release(release_id)
+        release = self.release_store.get_release(release_id)
 
         if release is None:
             raise ValueError(f"No releases found {release_id}, cannot continue!")

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -33,11 +33,14 @@ class Projects:
         except KeyError:
             raise ConfigError(f"No matching project {project_id} in {self.projects}")
 
-        prepare_config(config, **kwargs)
+        try:
+            region_name = config["region_name"]
+        except KeyError:
+            region_name = DEFAULT_REGION_NAME
 
         release_store = DynamoReleaseStore(
             project_id=project_id,
-            region_name=config["region_name"],
+            region_name=region_name,
             role_arn=config["role_arn"]
         )
 
@@ -46,46 +49,6 @@ class Projects:
             config=config,
             release_store=release_store
         )
-
-
-def prepare_config(
-        config,
-        *,
-        role_arn=None,
-        region_name=None
-):
-    """
-    Prepare the config.  Fill in overrides or defaults as necessary.
-    """
-    # We always want a role_arn to be set.  Read it from the initial config,
-    # or raise an error if not -- there's no way to pick a sensible default.
-    if role_arn:
-        if ("role_arn" in config) and (config["role_arn"] != role_arn):
-            warnings.warn(
-                f"Preferring override role_arn {role_arn} "
-                f"to role_arn in config {config['role_arn']}"
-            )
-            config["role_arn"] = role_arn
-        elif "role_arn" not in config:
-            config["role_arn"] = role_arn
-
-    if "role_arn" not in config:
-        raise ConfigError("role_arn is not set!")
-
-    assert "role_arn" in config
-
-    # We always want a region_name to be set.  Read it from the initial config
-    # if possible, or use the override or default if not.
-    if region_name and ("region_name" in config) and (config["region_name"] != region_name):
-        warnings.warn(
-            f"Preferring override region_name {region_name} "
-            f"to region_name in config {config['region_name']}"
-        )
-        config["region_name"] = region_name
-    elif "region_name" not in config:
-        config["region_name"] = region_name or DEFAULT_REGION_NAME
-
-    assert "region_name" in config
 
 
 class Project:

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -242,29 +242,6 @@ class Project:
 
         return is_deployed
 
-    def publish(self, image_id, label):
-        # Create an ECR client for the correct account
-        self.ecr.login()
-
-        remote_uri, remote_tag, local_tag = self.ecr.publish_image(
-            image_id=image_id,
-        )
-
-        tag_result = self.ecr.tag_image(
-            image_id=image_id,
-            tag=remote_tag,
-            new_tag=label
-        )
-
-        return {
-            'ecr_push': {
-                'local_tag': local_tag,
-                'remote_tag': remote_tag,
-                'remote_uri': remote_uri,
-            },
-            'ecr_tag': tag_result
-        }
-
     def get_images(self, from_label):
         """
         Returns a dict (image id) -> (Git ref tag).

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -1,7 +1,5 @@
 import datetime
 import functools
-import uuid
-import warnings
 
 import cattr
 import yaml
@@ -9,7 +7,7 @@ import yaml
 from . import ecs, iam, models
 from .ecr import EcrPrivate
 from .exceptions import ConfigError
-from .release_store import DynamoReleaseStore, ReleaseNotFoundError
+from .release_store import DynamoReleaseStore
 from .tags import parse_aws_tags
 
 DEFAULT_REGION_NAME = "eu-west-1"
@@ -97,7 +95,6 @@ class Project:
             "description": description,
             "details": details
         }
-
 
     def get_ecs_services(self, release, environment_id):
         # We always get a fresh set of ECS service descriptions.

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -149,25 +149,6 @@ class Project:
             "deployments": []
         }
 
-    def get_deployments(self, release_id, limit, environment_id):
-        if release_id is not None:
-            release = self.release_store.get_release(release_id)
-
-            # TODO: I think the release ID is already stored on the deployments.
-            # Can we remove this loop?
-            for d in release["deployments"]:
-                assert d["release_id"] == release_id
-
-            deployments = release["deployments"]
-        else:
-            deployments = self.release_store.get_recent_deployments(
-                environment=environment_id,
-                limit=limit
-            )
-
-        deployments = sorted(deployments, key=lambda d: d["date_created"], reverse=True)
-        return deployments[:limit]
-
     def get_release(self, release_id):
         if release_id == "latest":
             return self.release_store.get_most_recent_release()

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -272,8 +272,7 @@ class Project:
         Note: a single Docker image may have multiple ref tags, so the ref tag
         is chosen arbitrarily.
         """
-        ref_tags_resp = ecr.get_ref_tags_for_repositories(
-            self.ecr._underlying.client,
+        ref_tags_resp = self.ecr._underlying.get_ref_tags_for_repositories(
             image_repositories=self.image_repositories.keys(),
             tag=from_label
         )

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -354,11 +354,6 @@ class Project:
         if release is None:
             raise ValueError(f"No releases found {release_id}, cannot continue!")
 
-        matched_services = self.get_ecs_services(
-            release=release,
-            environment_id=environment_id
-        )
-
         # Force check for valid environment
         if environment_id not in self.environment_names:
             raise ValueError(
@@ -384,6 +379,11 @@ class Project:
                 )
 
             return ecs_services_deployed[service_arn]
+
+        matched_services = self.get_ecs_services(
+            release=release,
+            environment_id=environment_id
+        )
 
         for image_id, image_name in sorted(release['images'].items()):
             tag_result = self._tag_ecr_image(

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -6,7 +6,7 @@ import warnings
 import cattr
 import yaml
 
-from . import ecs, ecr, iam, models
+from . import ecs, iam, models
 from .ecr import EcrPrivate
 from .exceptions import ConfigError
 from .release_store import DynamoReleaseStore, ReleaseNotFoundError

--- a/src/deploy/release_store.py
+++ b/src/deploy/release_store.py
@@ -77,6 +77,27 @@ class ReleaseStore(abc.ABC):
         """
         pass
 
+    def get_deployments(self, *, release_id, environment_id, limit):
+        if release_id is not None:
+            release = self.get_release(release_id)
+
+            # TODO: I think the release ID is already stored on the deployments.
+            # Can we remove this loop?
+            for d in release["deployments"]:
+                assert d["release_id"] == release_id
+
+            deployments = release["deployments"]
+        else:
+            deployments = self.get_recent_deployments(
+                environment=environment_id,
+                limit=limit
+            )
+
+        deployments = sorted(
+            deployments, key=lambda d: d["date_created"], reverse=True
+        )
+        return deployments[:limit]
+
 
 class MemoryReleaseStore(ReleaseStore):
     def __init__(self):

--- a/src/deploy/release_store.py
+++ b/src/deploy/release_store.py
@@ -41,11 +41,17 @@ class ReleaseStore(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_release(self, release_id):
+    def _get_release_by_id(self, release_id):
         """
         Retrieve a previously stored release.
         """
         pass
+
+    def get_release(self, release_id):
+        if release_id == "latest":
+            return self.get_most_recent_release()
+        else:
+            return self._get_release_by_id(release_id)
 
     @abc.abstractmethod
     def get_recent_releases(self, *, limit):
@@ -112,7 +118,7 @@ class MemoryReleaseStore(ReleaseStore):
     def put_release(self, release):
         self.cache[release["release_id"]] = release
 
-    def get_release(self, release_id):
+    def _get_release_by_id(self, release_id):
         try:
             return self.cache[release_id]
         except KeyError:
@@ -176,7 +182,7 @@ class DynamoReleaseStore(ReleaseStore):
     def put_release(self, release):
         self.table.put_item(Item=release)
 
-    def get_release(self, release_id):
+    def _get_release_by_id(self, release_id):
         resp = self.table.get_item(Key={"release_id": release_id})
         try:
             return resp["Item"]

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -81,7 +81,7 @@ class TestGetRefTagsForImage:
 
 @moto.mock_sts()
 @moto.mock_iam()
-def test_get_ref_tags_for_repositories(ecr_client, region_name):
+def test_get_ref_tags_for_repositories(ecr_client, role_arn, region_name):
     manifest1 = create_image_manifest()
     ecr_client.create_repository(
         repositoryName="uk.ac.wellcome/example_worker1"
@@ -131,8 +131,9 @@ def test_get_ref_tags_for_repositories(ecr_client, region_name):
         },
     }
 
-    uris = ecr.get_ref_tags_for_repositories(
-        ecr_client,
+    ecr_private = ecr.EcrPrivate(role_arn=role_arn, region_name=region_name)
+
+    uris = ecr_private.get_ref_tags_for_repositories(
         image_repositories=image_repositories,
         tag="latest"
     )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 
 from deploy.exceptions import ConfigError

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -192,36 +192,6 @@ class TestProject:
             "prod": Environment(id="prod", name="Prod"),
         }
 
-    def test_get_release(self, role_arn, project_id):
-        releases = [
-            {
-                "release_id": f"release-{i}",
-                "project_id": project_id,
-                "date_created": datetime.datetime(2001, 1, i).isoformat(),
-                "last_date_deployed": datetime.datetime.now().isoformat()
-            }
-            for i in range(1, 10)
-        ]
-
-        release_store = MemoryReleaseStore()
-
-        for r in releases:
-            release_store.put_release(r)
-
-        project = Project(
-            project_id=project_id,
-            config={
-                "role_arn": role_arn,
-                "name": "Example Project",
-            },
-            release_store=release_store
-        )
-
-        assert project.get_release("latest") == releases[-1]
-
-        for r in releases:
-            assert project.get_release(release_id=r["release_id"]) == r
-
     def test_prepare_no_release_available(self, role_arn, project_id):
         release_store = MemoryReleaseStore()
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2,7 +2,7 @@ import pytest
 
 from deploy.exceptions import ConfigError
 from deploy.models import Environment, ImageRepository, Service
-from deploy.project import prepare_config, Projects, Project
+from deploy.project import Projects, Project
 from deploy.release_store import MemoryReleaseStore
 
 
@@ -16,98 +16,6 @@ def test_loading_non_existent_project_is_runtimeerror(tmpdir):
 
     with pytest.raises(ConfigError, match="No matching project doesnotexist"):
         project.load(project_id="doesnotexist")
-
-
-class TestPrepareConfig:
-    def test_allows_overriding_role_arn(self, role_arn):
-        """
-        If there is no role_arn in the initial config, but an override role_arn
-        is supplied, that role_arn is added to the config.
-        """
-        config = {}
-        prepare_config(config, role_arn=role_arn)
-        assert config["role_arn"] == role_arn
-
-    def test_warns_if_role_arn_conflict(self, role_arn):
-        """
-        If there is a role_arn in the initial config, and a differnet override
-        is supplied, then a warning is shown.
-        """
-        config = {"role_arn": role_arn}
-
-        with pytest.warns(UserWarning, match="Preferring override role_arn"):
-            prepare_config(config, role_arn=role_arn + "_alt")
-
-        assert config["role_arn"] == role_arn + "_alt"
-
-    def test_does_not_warn_if_role_arn_match(self, role_arn):
-        """
-        If there is a role_arn in the initial config, and it matches the override,
-        then no warning is shown.
-        """
-        config = {"role_arn": role_arn}
-
-        with pytest.warns(None) as record:
-            prepare_config(config, role_arn=role_arn)
-
-        assert len(record) == 0
-
-    def test_errors_if_no_role_arn(self, role_arn):
-        """
-        If there is no role_arn in the initial config or override, then an
-        error is thrown.
-        """
-        with pytest.raises(ConfigError, match="role_arn is not set"):
-            prepare_config(config={})
-
-    def test_uses_config_region_name(self, role_arn):
-        """
-        ProjectConfig uses the region_name in the initial config.
-        """
-        config = {"region_name": "us-east-2", "role_arn": role_arn}
-        prepare_config(config)
-        assert config["region_name"] == "us-east-2"
-
-    def test_allows_overriding_region_name(self, role_arn):
-        """
-        If there is no region_name in the initial config, but an override region_name
-        is supplied, that region_name is added to the config.
-        """
-        config = {"role_arn": role_arn}
-        prepare_config(config, region_name="eu-north-1")
-        assert config["region_name"] == "eu-north-1"
-
-    def test_uses_default_region_name(self, role_arn):
-        """
-        If there is no region_name in the initial config, and no override is supplied,
-        then the default region_name is added to the config.
-        """
-        config = {"role_arn": role_arn}
-        prepare_config(config)
-        assert config["region_name"] == "eu-west-1"
-
-    def test_warns_if_region_name_conflict(self, role_arn):
-        """
-        If there is a region_name in the initial config, and a different override
-        is supplied, then a warning is shown.
-        """
-        config = {"region_name": "eu-west-1", "role_arn": role_arn}
-        with pytest.warns(UserWarning, match="Preferring override"):
-            prepare_config(config, region_name="us-east-1")
-
-        assert config["region_name"] == "us-east-1"
-
-    def test_does_not_warn_if_region_name_match(self, role_arn):
-        """
-        If there is a region_name in the initial config, and it matches the override,
-        then no warning is shown.
-        """
-        config = {"region_name": "eu-west-1", "role_arn": role_arn}
-
-        with pytest.warns(None) as record:
-            prepare_config(config, region_name="eu-west-1")
-
-        assert len(record) == 0
 
 
 class TestProject:

--- a/tests/test_release_store.py
+++ b/tests/test_release_store.py
@@ -204,6 +204,28 @@ class ReleaseStoreTestsMixin:
             assert len(stored_release["deployments"]) == 4
             assert stored_release["last_date_deployed"] == deployment["date_created"]
 
+    def test_get_release(self, project_id):
+        releases = [
+            {
+                "release_id": f"release-{i}",
+                "project_id": project_id,
+                "date_created": datetime.datetime(2001, 1, i).isoformat(),
+                "last_date_deployed": datetime.datetime.now().isoformat()
+            }
+            for i in range(1, 10)
+        ]
+
+        with self.create_release_store(project_id) as release_store:
+            release_store.initialise()
+
+            for r in releases:
+                release_store.put_release(r)
+
+            assert release_store.get_release("latest") == releases[-1]
+
+            for r in releases:
+                assert release_store.get_release(release_id=r["release_id"]) == r
+
 
 class TestMemoryReleaseStore(ReleaseStoreTestsMixin):
     @contextlib.contextmanager


### PR DESCRIPTION
Yet another bit of refactoring towards https://github.com/wellcomecollection/platform/issues/5112, with no user-visible effect

The old Project class in `project.py` mixes together a whole bunch of stuff, as well as representing some of the config in a `.wellcome_project` file. This patch continues to move methods out to other, more tightly-scoped classes.

I've also binned the last of the old config validation, which is now handled by the model classes.