### PR TITLE
Fix a bug where types are not dictionaries

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a bug introduced in the recent refactoring work.


### PR DESCRIPTION
The crux of this bug is in these two lines:

    matched_image = self.image_repositories[image_id]
    services = matched_image.get('services', [])

Thanks to the new types, `matched_image` is now a type (ImageRepository) rather than a dict -- so the `.get()` method no longer works.  This wasn't caught by tests because we weren't testing the function that includes these lines.

*   I've converted most of the function to a pure function, and added a test for it.
*   I've fixed the underlying issue, and simplified the function to reflect how its return value actually gets used.