### PR TITLE
Fix another bug in weco-deploy

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a bug introduced in recent refactoring.

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -1,3 +1,4 @@
+import collections
 import typing
 
 from . import tags
@@ -175,14 +176,8 @@ def find_ecs_services_for_release(
     """
     Returns a map (image ID) -> Dict(service ID -> ECS service description)
     """
-    def _find_service(service_id):
-        return find_matching_service(
-            service_descriptions=service_descriptions,
-            service_id=service_id,
-            environment_id=environment_id
-        )
+    matched_services = collections.defaultdict(dict)
 
-    matched_services = {}
     for image_id, _ in release['images'].items():
         # Attempt to match deployment image id to config and override service_ids
         try:
@@ -190,9 +185,14 @@ def find_ecs_services_for_release(
         except KeyError:
             continue
 
-        matched_services[image_id] = {
-            service_id: _find_service(service_id)
-            for service_id in matched_image.services
-        }
+        for service_id in matched_image.services:
+            try:
+                matched_services[image_id] = find_matching_service(
+                    service_descriptions=service_descriptions,
+                    service_id=service_id,
+                    environment_id=environment_id
+                )
+            except NoMatchingServiceError:
+                pass
 
     return matched_services

--- a/src/deploy/ecs.py
+++ b/src/deploy/ecs.py
@@ -187,11 +187,15 @@ def find_ecs_services_for_release(
 
         for service_id in matched_image.services:
             try:
-                matched_services[image_id] = find_matching_service(
+                service_description = find_matching_service(
                     service_descriptions=service_descriptions,
                     service_id=service_id,
                     environment_id=environment_id
                 )
+
+                matched_services[image_id] = {
+                    service_id: service_description
+                }
             except NoMatchingServiceError:
                 pass
 

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -350,5 +350,6 @@ def test_find_ecs_services_for_release(session, ecs_stack):
     )
 
     assert resp == {
+        "repo1": {"service1": service_1_prod},
         "repo2": {"service2": service_2_prod},
     }

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -350,6 +350,5 @@ def test_find_ecs_services_for_release(session, ecs_stack):
     )
 
     assert resp == {
-        "repo1": {"service1": service_1_prod},
         "repo2": {"service2": service_2_prod},
     }


### PR DESCRIPTION
I changed the behaviour of find_matching_service to throw an explicit exception rather than return None in a recent refactoring, but I forgot to update the calling code to handle that exception properly.