### PR TITLE
Add a check for missing image in release and better error display

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Add a check on missing images when preparing releases and improve known error display.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -541,4 +541,3 @@ def main():
     except (WecoDeployError, ConfigError) as err:
         click.echo(click.style(f"Failed: {err}", fg="bright_red"))
         sys.exit(1)
-

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -10,6 +10,7 @@ from pprint import pprint
 from tabulate import tabulate
 
 from . import ecs, git, iam
+from .exceptions import ConfigError, WecoDeployError
 from .pretty_printing import pprint_date
 from .project import Projects
 from .version_check import warn_if_not_latest_version, current_version
@@ -535,4 +536,9 @@ def show_images(ctx, label):
 
 
 def main():
-    cli()
+    try:
+        cli()
+    except (WecoDeployError, ConfigError) as err:
+        click.echo(click.style(f"Failed: {err}", fg="bright_red"))
+        sys.exit(1)
+

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -193,7 +193,8 @@ class Project:
             raise WecoDeployError(f"No images found for {self.id}/{from_label}")
 
         for service_id, release_ref in release_images.items():
-            raise WecoDeployError(f"No image found for {self.id}/{from_label}/{service_id}")
+            if release_ref is None:
+                raise WecoDeployError(f"No image found for {self.id}/{from_label}/{service_id}")
 
         return self.release_store.prepare_release(
             project_id=self.id,

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -6,7 +6,7 @@ import yaml
 
 from . import ecs, iam, models
 from .ecr import EcrPrivate
-from .exceptions import ConfigError
+from .exceptions import ConfigError, WecoDeployError
 from .release_store import DynamoReleaseStore
 from .tags import parse_aws_tags
 
@@ -190,7 +190,10 @@ class Project:
         release_images = self.get_images(from_label)
 
         if not release_images:
-            raise RuntimeError(f"No images found for {self.id}/{from_label}")
+            raise WecoDeployError(f"No images found for {self.id}/{from_label}")
+
+        for service_id, release_ref in release_images.items():
+            raise WecoDeployError(f"No image found for {self.id}/{from_label}/{service_id}")
 
         return self.release_store.prepare_release(
             project_id=self.id,
@@ -206,7 +209,7 @@ class Project:
         # Ensure all specified services are available as images
         for service_id in service_ids:
             if service_id not in images.keys():
-                raise RuntimeError(f"No images found for {service_id}")
+                raise WecoDeployError(f"No images found for {service_id}")
 
         # Filter to only specified images
         filtered_images = {k: v for k, v in images.items() if k in service_ids}
@@ -237,11 +240,11 @@ class Project:
         release = self.release_store.get_release(release_id)
 
         if release is None:
-            raise ValueError(f"No releases found {release_id}, cannot continue!")
+            raise WecoDeployError(f"No releases found {release_id}, cannot continue!")
 
         # Force check for valid environment
         if environment_id not in self.environment_names:
-            raise ValueError(
+            raise WecoDeployError(
                 f"Unknown environment. "
                 f"Got {environment_id!r}, expected {self.environment_names.keys()!r}"
             )


### PR DESCRIPTION
Check when we `prepare` that images are available to avoid an error handling a deployment where no image is available. 

Identifying this error prompted the following change:

In order to make known errors more easily understandable this change also adds a try/catch around enterpoint to click & catch user-defined errors `ConfigError` & `WecoDeployError` - highlight these errors and hide their stack trace.