### PR TITLE
Tolerate missing images for some services

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Tolerate missing images for some services within a project in a release.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -322,7 +322,9 @@ def _display_release(release, from_label):
         #
         #     {ecr_repo_uri}/{namespace}/{service}:ref.{git_commit}
         #
+
         prev_git_commit = "-------"
+        new_git_commit = "-------"
         prev_release_images = None
 
         if prev_release is not None:
@@ -331,7 +333,8 @@ def _display_release(release, from_label):
         if prev_release_images is not None:
             prev_git_commit = prev_release_images.split(".")[-1][:7]
 
-        new_git_commit = image.split(".")[-1][:7]
+        if image is not None:
+            new_git_commit = image.split(".")[-1][:7]
 
         rows.append([
             service,

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -324,7 +324,7 @@ def _display_release(release, from_label):
         #
 
         prev_git_commit = "-------"
-        new_git_commit = click.style(f"No image found!", fg="bright_magenta")
+        new_git_commit = click.style("No image found!", fg="bright_magenta")
 
         prev_release_images = None
 

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -324,7 +324,8 @@ def _display_release(release, from_label):
         #
 
         prev_git_commit = "-------"
-        new_git_commit = "-------"
+        new_git_commit = click.style(f"No image found!", fg="bright_magenta")
+
         prev_release_images = None
 
         if prev_release is not None:

--- a/src/deploy/project.py
+++ b/src/deploy/project.py
@@ -192,10 +192,6 @@ class Project:
         if not release_images:
             raise WecoDeployError(f"No images found for {self.id}/{from_label}")
 
-        for service_id, release_ref in release_images.items():
-            if release_ref is None:
-                raise WecoDeployError(f"No image found for {self.id}/{from_label}/{service_id}")
-
         return self.release_store.prepare_release(
             project_id=self.id,
             project=self._underlying,
@@ -279,6 +275,9 @@ class Project:
         )
 
         for image_id, image_name in sorted(release['images'].items()):
+            if image_name is None:
+                continue
+
             tag_result = self._tag_ecr_image(
                 environment_id=environment_id,
                 image_id=image_id,


### PR DESCRIPTION
This change makes preparing or deploying releases where there are missing images for some services for a particular release label possible.