### PR TITLE
Improve the reporting of durations in weco-deploy output

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Improve the reporting of durations in weco-deploy output, e.g. `5m 30s` instead of `330s`.

--- a/src/deploy/deploy.py
+++ b/src/deploy/deploy.py
@@ -11,7 +11,7 @@ from tabulate import tabulate
 
 from . import ecs, git, iam
 from .exceptions import ConfigError, WecoDeployError, NothingToReleaseError
-from .pretty_printing import pprint_date
+from .pretty_printing import pprint_date, pprint_duration
 from .project import Projects
 from .version_check import warn_if_not_latest_version, current_version
 
@@ -311,8 +311,16 @@ def _confirm_deploy(project, release, environment_id, wait_for_seconds, interval
     release_id = release["release_id"]
 
     click.echo("")
-    click.echo(click.style(f"Checking deployment of {release_id} to {environment_id}", fg="yellow"))
-    click.echo(click.style(f"Allowing {wait_for_seconds}s for deployment.", fg="yellow"))
+    click.echo(
+        click.style(
+            f"Checking deployment of {release_id} to {environment_id}", fg="yellow"
+        )
+    )
+    click.echo(
+        click.style(
+            f"Allowing {pprint_duration(wait_for_seconds)} for deployment.", fg="yellow"
+        )
+    )
 
     while not project.is_release_deployed(release, environment_id, verbose):
         total_time_waited = int(time.perf_counter() - start_timer)
@@ -321,11 +329,20 @@ def _confirm_deploy(project, release, environment_id, wait_for_seconds, interval
 
         if exceeded_wait_time:
             click.echo("")
-            click.echo(click.style(f"Deployment of {release_id} to {environment_id} failed", fg="red"))
-            click.echo(click.style(f"Deployment time exceeded {wait_for_seconds}s", fg="red"))
+            click.echo(
+                click.style(
+                    f"Deployment of {release_id} to {environment_id} failed", fg="red"
+                )
+            )
+            click.echo(
+                click.style(
+                    f"Deployment time exceeded {pprint_duration(wait_for_seconds)}",
+                    fg="red",
+                )
+            )
             sys.exit(1)
 
-        retry_message = f"Trying again in {interval}s (waited {total_time_waited}s)."
+        retry_message = f"Trying again in {pprint_duration(interval)} (waited {pprint_duration(total_time_waited)} so far)."
         click.echo(click.style(retry_message, fg="yellow"))
 
         time.sleep(interval)

--- a/src/deploy/pretty_printing.py
+++ b/src/deploy/pretty_printing.py
@@ -4,7 +4,7 @@ import datetime
 def pprint_date(date_obj, *, now=datetime.datetime.now()):
     assert date_obj <= now
 
-    difference = (now - date_obj)
+    difference = now - date_obj
 
     is_today = date_obj.date() == now.date()
     is_yesterday = date_obj.date() == (now - datetime.timedelta(days=1)).date()
@@ -12,11 +12,15 @@ def pprint_date(date_obj, *, now=datetime.datetime.now()):
     if difference.total_seconds() <= 120:
         return "just now"
     elif is_today and difference.total_seconds() <= 60 * 60:
-        return date_obj.strftime("today @ %H:%M") + " (%d min ago)" % (difference.total_seconds() // 60)
+        return date_obj.strftime("today @ %H:%M") + " (%d min ago)" % (
+            difference.total_seconds() // 60
+        )
     elif is_today:
         return date_obj.strftime("today @ %H:%M")
     elif is_yesterday and difference.total_seconds() <= 60 * 60:
-        return date_obj.strftime("yesterday @ %H:%M") + " (%d min ago)" % (difference.total_seconds() // 60)
+        return date_obj.strftime("yesterday @ %H:%M") + " (%d min ago)" % (
+            difference.total_seconds() // 60
+        )
     elif is_yesterday:
         return date_obj.strftime("yesterday @ %H:%M")
     else:
@@ -29,3 +33,26 @@ def pprint_date(date_obj, *, now=datetime.datetime.now()):
             return result.replace(" 0", "  ", 1)
         else:
             return result
+
+
+def pprint_duration(seconds):
+    """
+    Pretty-prints a duration.
+
+    Examples:
+        1m
+        2m 3s
+
+    Not meant for durations more than an hour.
+
+    """
+    if seconds < 60:
+        return f"{seconds}s"
+    else:
+        minutes = seconds // 60
+        seconds %= 60
+
+        if seconds == 0:
+            return f"{minutes}m"
+        else:
+            return f"{minutes}m {seconds}s"

--- a/tests/test_pretty_printing.py
+++ b/tests/test_pretty_printing.py
@@ -2,22 +2,39 @@ import datetime
 
 import pytest
 
-from deploy.pretty_printing import pprint_date
+from deploy.pretty_printing import pprint_date, pprint_duration
 
 
-@pytest.mark.parametrize("date_obj, now, expected_str", [
-    ("2020-01-01 12:00:00", "2020-01-01 12:00:01", "just now"),
-    ("2020-01-01 12:00:00", "2020-01-01 12:02:00", "just now"),
-    ("2020-01-01 12:00:00", "2020-01-01 12:02:02", "today @ 12:00 (2 min ago)"),
-    ("2020-01-01 12:00:00", "2020-01-01 15:00:00", "today @ 12:00"),
-    ("2020-01-01 23:59:00", "2020-01-02 00:02:00", "yesterday @ 23:59 (3 min ago)"),
-    ("2020-01-01 12:00:00", "2020-01-02 12:00:00", "yesterday @ 12:00"),
-    ("2019-01-01 12:00:00", "2020-01-02 12:00:00", "Tue  1 January 2019 @ 12:00"),
-    ("2019-01-01 01:00:00", "2020-01-02 12:00:00", "Tue  1 January 2019 @ 01:00"),
-    ("2019-01-20 12:00:00", "2020-01-02 12:00:00", "Sun 20 January 2019 @ 12:00"),
-])
+@pytest.mark.parametrize(
+    "date_obj, now, expected_str",
+    [
+        ("2020-01-01 12:00:00", "2020-01-01 12:00:01", "just now"),
+        ("2020-01-01 12:00:00", "2020-01-01 12:02:00", "just now"),
+        ("2020-01-01 12:00:00", "2020-01-01 12:02:02", "today @ 12:00 (2 min ago)"),
+        ("2020-01-01 12:00:00", "2020-01-01 15:00:00", "today @ 12:00"),
+        ("2020-01-01 23:59:00", "2020-01-02 00:02:00", "yesterday @ 23:59 (3 min ago)"),
+        ("2020-01-01 12:00:00", "2020-01-02 12:00:00", "yesterday @ 12:00"),
+        ("2019-01-01 12:00:00", "2020-01-02 12:00:00", "Tue  1 January 2019 @ 12:00"),
+        ("2019-01-01 01:00:00", "2020-01-02 12:00:00", "Tue  1 January 2019 @ 01:00"),
+        ("2019-01-20 12:00:00", "2020-01-02 12:00:00", "Sun 20 January 2019 @ 12:00"),
+    ],
+)
 def test_pprint_date(date_obj, now, expected_str):
     date_obj = datetime.datetime.strptime(date_obj, "%Y-%m-%d %H:%M:%S")
     now = datetime.datetime.strptime(now, "%Y-%m-%d %H:%M:%S")
 
     assert pprint_date(date_obj, now=now) == expected_str
+
+
+@pytest.mark.parametrize(
+    "seconds, expected_str",
+    [
+        (1, "1s"),
+        (59, "59s"),
+        (60, "1m"),
+        (62, "1m 2s"),
+        (180, "3m"),
+    ],
+)
+def test_pprint_duration(seconds, expected_str):
+    assert pprint_duration(seconds) == expected_str


### PR DESCRIPTION
A small, hopefully uncontroversial change, extracted from https://github.com/wellcomecollection/weco-deploy/pull/121