### PR TITLE
Fix a bug when parsing ECR image URIs with hyphens in the tags

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
       - docker-compose#v3.5.0:
           run: tox
           env:
-            - TOXENV=py37
+            - TOXENV=py39
   - wait
   - label: "pypi publish"
     if: build.branch == "main"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a bug when parsing ECR image URIs with hyphens in the tags (e.g. `env.2022-09-01`).

--- a/src/deploy/ecr.py
+++ b/src/deploy/ecr.py
@@ -315,7 +315,7 @@ def parse_ecr_image_uri(image_uri):
         r"\.dkr\.ecr\.eu-west-1\.amazonaws.com/"
         r"(?P<repository_name>[^:]+)"
         r":"
-        r"(?P<image_tag>[a-z0-9\.-_]+)",
+        r"(?P<image_tag>[a-z0-9\.\-_]+)",
         image_uri,
     )
 

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -167,3 +167,28 @@ def test_get_ref_tags_for_repositories(ecr_client, role_arn, region_name):
         "example_worker2": set(["ref.222"]),
         "example_worker3": set(),
     }
+
+
+@pytest.mark.parametrize(
+    "image_uri, expected_result",
+    [
+        (
+            "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_apigw:f1188c2a7df01663dd96c99b26666085a4192167",
+            {
+                "registry_id": "760097843905",
+                "repository_name": "uk.ac.wellcome/nginx_apigw",
+                "image_tag": "f1188c2a7df01663dd96c99b26666085a4192167",
+            },
+        ),
+        (
+            "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/id_minter:env.2022-08-24",
+            {
+                "registry_id": "760097843905",
+                "repository_name": "uk.ac.wellcome/id_minter",
+                "image_tag": "env.2022-08-24",
+            },
+        )
+    ],
+)
+def test_parse_ecr_image_uri(image_uri, expected_result):
+    assert ecr.parse_ecr_image_uri(image_uri) == expected_result


### PR DESCRIPTION
This is what's breaking the current pipeline deployment: https://buildkite.com/wellcomecollection/catalogue-pipeline-deploy-pipeline/builds/325#_

We're extracting `env.2022-08-24` as `env.2022`, which doesn't exist.